### PR TITLE
Make worker module configurable on the connection pool level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,10 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.1.1] - 2020-11-17
+
 ### Changed
 
-- Configure the worker module on the `Snowflex.ConnectionPool`
+- Configure the worker module on the `Snowflex.ConnectionPool` and no longer on the application level.
 
-- _Breaking_ Users must launch connection pools as part of their application's
+## [0.1.0] - 2020-11-16
+
+### Breaking
+
+- Users must launch connection pools as part of their application's
   supervision tree using `Snowflex.ConnectionPool`, and all queries must specify
   which connection pool to use. No connection pool will be started by default.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
-- *Breaking* Users must launch connection pools as part of their application's
+- Configure the worker module on the `Snowflex.ConnectionPool`
+
+- _Breaking_ Users must launch connection pools as part of their application's
   supervision tree using `Snowflex.ConnectionPool`, and all queries must specify
   which connection pool to use. No connection pool will be started by default.

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ The following config options can be set:
 ```elixir
 config :snowflex,
   driver: "/path/to/my/ODBC/driver" # defaults to "/usr/lib/snowflake/odbc/lib/libSnowflake.so")
-  worker: MyApp.MockWorker # defaults to Snowflex.Worker (change for testing/development)
 ```
 
 Connection pools are not automatically started for you. You will need to establish each connection pool in your application module. Example configuration:
@@ -33,6 +32,7 @@ config :my_app, :data_warehouses,
   ],
   advertising: [
     name: :advertising,
+    worker_module: MyApp.MockWorker # defaults to Snowflex.Worker (change for testing/development)
     connection: [
       role: "PROD",
       warehouse: System.get_env("SNOWFLAKE_ADVERTISING_WH"),
@@ -81,7 +81,7 @@ The package can be installed by adding `snowflex` to your list of dependencies i
 ```elixir
 def deps do
   [
-    {:snowflex, "~> 0.1.0"}
+    {:snowflex, "~> 0.1.1"}
   ]
 end
 ```

--- a/lib/connection_pool.ex
+++ b/lib/connection_pool.ex
@@ -72,6 +72,10 @@ defmodule Snowflex.ConnectionPool do
 
   The `:name` of the connection pool must be an atom.
 
+  ## Worker Module
+
+  The `:worker_module` configuration is used to specifiy a different worker for the pool. We recommend this be used to setup a mock worker for testing/development.
+
   ## Connection
 
   The `:connection` configuration contains details on how to connect to
@@ -125,10 +129,11 @@ defmodule Snowflex.ConnectionPool do
 
     min_pool_size = Keyword.get(final_size_config, :min)
     max_pool_size = Keyword.get(final_size_config, :max)
+    worker_module = Keyword.get(config, :worker_module, Snowflex.Worker)
 
     opts = [
       {:name, {:local, name}},
-      {:worker_module, Application.get_env(:snowflex, :worker, Snowflex.Worker)},
+      {:worker_module, worker_module},
       {:size, max_pool_size},
       {:max_overflow, min_pool_size}
     ]

--- a/lib/snowflex/worker.ex
+++ b/lib/snowflex/worker.ex
@@ -20,11 +20,14 @@ defmodule Snowflex.Worker do
   end
 
   ## GENSERVER CALL BACKS
+
+  @impl GenServer
   def init(connection_args) do
     send(self(), {:start, connection_args})
     {:ok, %{backoff: :backoff.init(2, 60), state: :not_connected}}
   end
 
+  @impl GenServer
   def handle_call({:sql_query, _query}, _from, state = %{state: :not_connected}) do
     {:reply, {:err, :not_connected}, state}
   end
@@ -58,6 +61,7 @@ defmodule Snowflex.Worker do
     end
   end
 
+  @impl GenServer
   def handle_info({:start, connection_args}, %{backoff: backoff}) do
     conn_str = connection_string(connection_args)
 

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Snowflex.MixProject do
   def project do
     [
       app: :snowflex,
-      version: "0.1.0",
+      version: "0.1.1",
       elixir: "~> 1.9",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
@@ -33,7 +33,7 @@ defmodule Snowflex.MixProject do
   defp package do
     [
       # These are the default files included in the package
-      files: ~w(lib .formatter.exs mix.exs README* LICENSE*),
+      files: ~w(lib .formatter.exs mix.exs README* LICENSE* CHANGELOG*),
       licenses: ["Apache-2.0"],
       links: %{"GitHub" => "https://github.com/pepsico-ecommerce/snowflex"}
     ]


### PR DESCRIPTION
Since each `Snowflex.ConnectionPool` can represent different warehouses, allow users to setup mock workers per connection pool.