### PR TITLE
send connection args with start on backoff

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.2.1] - 2020-11-20
+
+### Fixed
+
+- fix bug where handle_info is missing argument
+
 ## [0.2.0] - 2020-11-18
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -1,5 +1,8 @@
 **THIS IS A WORK IN PROGRESS. USE AT YOUR OWN RISK.**
 
+[![Published on Hex](https://img.shields.io/hexpm/v/snowflex)](https://hex.pm/packages/snowflex)
+[![License Info](https://img.shields.io/hexpm/l/snowflex)](https://github.com/pepsico-ecommerce/snowflex/blob/master/LICENSE)
+
 # Snowflex ❄💪
 
 This application encapsulates an ODBC connection pool for connecting to the Snowflake data warehouse.
@@ -83,7 +86,7 @@ The package can be installed by adding `snowflex` to your list of dependencies i
 ```elixir
 def deps do
   [
-    {:snowflex, "~> 0.2.0"}
+    {:snowflex, "~> 0.2.1"}
   ]
 end
 ```

--- a/lib/snowflex/worker.ex
+++ b/lib/snowflex/worker.ex
@@ -77,7 +77,13 @@ defmodule Snowflex.Worker do
 
       {:error, reason} ->
         Logger.warn("Unable to connect to snowflake: #{reason}")
-        Process.send_after(self(), :start, backoff |> :backoff.get() |> :timer.seconds())
+
+        Process.send_after(
+          self(),
+          {:start, connection_args},
+          backoff |> :backoff.get() |> :timer.seconds()
+        )
+
         {_, new_backoff} = :backoff.fail(backoff)
         {:noreply, %{backoff: new_backoff, state: :not_connected}}
     end

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Snowflex.MixProject do
   def project do
     [
       app: :snowflex,
-      version: "0.2.0",
+      version: "0.2.1",
       elixir: "~> 1.9",
       start_permanent: Mix.env() == :prod,
       deps: deps(),


### PR DESCRIPTION
When `:start` fails, make sure it sends the connection to the next `:start` call.