### PR TITLE
Add fallback for results not in the form of rows

### DIFF
--- a/lib/snowflex.ex
+++ b/lib/snowflex.ex
@@ -91,6 +91,7 @@ defmodule Snowflex do
       end)
     end)
   end
+  defp process_results(results), do: results
 
   defp to_string_if_charlist(data) when is_list(data), do: to_string(data)
   defp to_string_if_charlist(data), do: data


### PR DESCRIPTION
When attempting to run a `CREATE STAGE my_stage;` command the `process_results` function currently fails because it only returns a single term.