### PR TITLE
Add map_nulls_to_nil configuration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.3.2] - 2021-06-02
+
+### Added
+- Added `map_nulls_to_nil?` variable to connection configuration to allow conversion of `:null` values to `:nil` in snowflake query response
+
 ## [0.3.1] - 2021-03-10
 
 ### Fixed

--- a/README.md
+++ b/README.md
@@ -53,6 +53,10 @@ config :my_app, MyApp.SnowflakeConnection,
     ]
 ```
 
+The odbc driver will, by default, return `:null` for empty values returned from snowflake queries.
+This will be converted to `nil` by default by Snowflex. A configuration value `map_nulls_to_nil?`
+can be set to `false` if you do not desire this behavior.
+
 Then, in your application module, you would start your connection:
 
 ```elixir

--- a/README.md
+++ b/README.md
@@ -16,14 +16,16 @@ config :snowflex,
   driver: "/path/to/my/ODBC/driver" # defaults to "/usr/lib/snowflake/odbc/lib/libSnowflake.so"
 ```
 
-Connection pools are not automatically started for you. You will need to define and establish each connection pool in your application module.
+Connection pools are not automatically started for you. You will need to define and establish each connection pool in your application module. configuration values related to connection timeouts and the mapping of `:null` query values can be set here.
 
 First, create a module to hold your connection information:
 
 ```elixir
 defmodule MyApp.SnowflakeConnection do
   use Snowflex.Connection,
-    otp_app: :my_app
+    otp_app: :my_app,
+    timeout: :timer.minutes(20),
+    map_nulls_to_nil?: true
 end
 ```
 

--- a/lib/snowflex.ex
+++ b/lib/snowflex.ex
@@ -51,9 +51,9 @@ defmodule Snowflex do
     end
   end
 
-  @spec param_query(atom(), String.t(), query_opts(), list(query_param())) ::
+  @spec param_query(atom(), String.t(), list(query_param()), query_opts()) ::
           sql_data() | {:error, term()}
-  def param_query(pool_name, query, opts, params) do
+  def param_query(pool_name, query, params, opts) do
     timeout = Keyword.get(opts, :timeout)
 
     case :poolboy.transaction(

--- a/lib/snowflex.ex
+++ b/lib/snowflex.ex
@@ -75,6 +75,8 @@ defmodule Snowflex do
   end
 
   defp process_results({:selected, headers, rows}) do
+    null_to_nil? = Application.get_env(:snowflex, :map_nulls_to_nil?, true)
+
     bin_headers =
       headers
       |> Enum.map(fn header -> header |> to_string() |> String.downcase() end)
@@ -86,6 +88,7 @@ defmodule Snowflex do
           row
           |> elem(index)
           |> to_string_if_charlist()
+          |> map_null_to_nil(null_to_nil?)
 
         Map.put(map, col, data)
       end)
@@ -94,6 +97,9 @@ defmodule Snowflex do
 
   defp to_string_if_charlist(data) when is_list(data), do: to_string(data)
   defp to_string_if_charlist(data), do: data
+
+  defp map_null_to_nil(:null, true), do: nil
+  defp map_null_to_nil(data, _), do: data
 
   defp cast_row(row, schema) do
     schema

--- a/lib/snowflex/connection.ex
+++ b/lib/snowflex/connection.ex
@@ -139,7 +139,7 @@ defmodule Snowflex.Connection do
 
       @impl Snowflex.Connection
       def execute(query, params) when is_binary(query) and is_list(params) do
-        Snowflex.param_query(@name, query, @query_opts, params)
+        Snowflex.param_query(@name, query, params, @query_opts)
       end
     end
   end

--- a/lib/snowflex/connection.ex
+++ b/lib/snowflex/connection.ex
@@ -91,17 +91,21 @@ defmodule Snowflex.Connection do
       # setup compile time config
       otp_app = Keyword.fetch!(opts, :otp_app)
       timeout = Keyword.get(opts, :timeout, :timer.seconds(60))
+      map_nulls_to_nil? = Keyword.get(opts, :map_nulls_to_nil?, false)
       keep_alive? = Keyword.get(opts, :keep_alive?, false)
 
       @otp_app otp_app
       @name __MODULE__
-      @timeout timeout
       @default_size [
         max: 10,
         min: 5
       ]
       @keep_alive? keep_alive?
       @heartbeat_interval :timer.hours(3)
+      @query_opts [
+        timeout: timeout,
+        map_nulls_to_nil?: map_nulls_to_nil?
+      ]
 
       def child_spec(_) do
         config = Application.get_env(@otp_app, __MODULE__, [])
@@ -130,12 +134,12 @@ defmodule Snowflex.Connection do
 
       @impl Snowflex.Connection
       def execute(query) when is_binary(query) do
-        Snowflex.sql_query(@name, query, @timeout)
+        Snowflex.sql_query(@name, query, @query_opts)
       end
 
       @impl Snowflex.Connection
       def execute(query, params) when is_binary(query) and is_list(params) do
-        Snowflex.param_query(@name, query, params, @timeout)
+        Snowflex.param_query(@name, query, @query_opts, params)
       end
     end
   end


### PR DESCRIPTION
The odbc used by Snowflex driver will, by default, return `:null` for empty values in a query rather than `nil`, a value native to Elixir. This pull requests adds translation of `:null` to `:nil` along with configuration to disable this feature if desired.