### PR TITLE
Enables insert queries

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+- Enabled SQL `INSERT` statements.
+
 ## [0.3.3] - 2021-06-07
 
 ### Fixed

--- a/lib/snowflex.ex
+++ b/lib/snowflex.ex
@@ -37,7 +37,7 @@ defmodule Snowflex do
   @type query_opts :: [timeout: timeout(), map_nulls_to_nil?: boolean()]
 
   @spec sql_query(atom(), String.t(), query_opts()) ::
-          sql_data() | {:error, term()}
+          sql_data() | {:error, term()} | {:updated, integer()}
   def sql_query(pool_name, query, opts) do
     timeout = Keyword.get(opts, :timeout)
 
@@ -52,7 +52,7 @@ defmodule Snowflex do
   end
 
   @spec param_query(atom(), String.t(), list(query_param()), query_opts()) ::
-          sql_data() | {:error, term()}
+          sql_data() | {:error, term()} | {:updated, integer()}
   def param_query(pool_name, query, params, opts) do
     timeout = Keyword.get(opts, :timeout)
 
@@ -99,6 +99,8 @@ defmodule Snowflex do
       end)
     end)
   end
+
+  defp process_results({:updated, _} = results, _opts), do: results
 
   defp to_string_if_charlist(data) when is_list(data), do: to_string(data)
   defp to_string_if_charlist(data), do: data

--- a/lib/snowflex/connection.ex
+++ b/lib/snowflex/connection.ex
@@ -149,11 +149,12 @@ defmodule Snowflex.Connection do
   @doc """
   Wraps `Snowflex.sql_query/3` and injects the relevant information from the connection
   """
-  @callback execute(query :: String.t()) :: Snowflex.sql_data() | {:error, any}
+  @callback execute(query :: String.t()) ::
+              Snowflex.sql_data() | {:error, any} | {:updated, integer()}
 
   @doc """
   Wraps `Snowflex.param_query/4` and injects the relevant information from the connection
   """
   @callback execute(query :: String.t(), params :: list(Snowflex.query_param())) ::
-              Snowflex.sql_data() | {:error, any}
+              Snowflex.sql_data() | {:error, any} | {:updated, integer()}
 end

--- a/test/snowflex/connection_test.exs
+++ b/test/snowflex/connection_test.exs
@@ -21,8 +21,16 @@ defmodule Snowflex.ConnectionTest do
       {:ok, %{}}
     end
 
+    def handle_call({:sql_query, "insert " <> _}, _from, state) do
+      {:reply, {:ok, {:updated, 123}}, state}
+    end
+
     def handle_call({:sql_query, _}, _from, state) do
       {:reply, {:ok, {:selected, ['col'], [{1}, {2}]}}, state}
+    end
+
+    def handle_call({:param_query, "insert " <> _, _}, _from, state) do
+      {:reply, {:ok, {:updated, 123}}, state}
     end
 
     def handle_call({:param_query, _, _}, _from, state) do
@@ -36,6 +44,12 @@ defmodule Snowflex.ConnectionTest do
 
       assert [%{"col" => 1}, %{"col" => 2}] == SnowflakeConnection.execute("my query")
     end
+
+    test "should execute an insert query" do
+      start_supervised!(SnowflakeConnection)
+
+      assert {:updated, 123} == SnowflakeConnection.execute("insert query")
+    end
   end
 
   describe "execute/2" do
@@ -43,6 +57,12 @@ defmodule Snowflex.ConnectionTest do
       start_supervised!(SnowflakeConnection)
 
       assert [%{"col" => 1}, %{"col" => 2}] == SnowflakeConnection.execute("my query", [])
+    end
+
+    test "should execute an insert param query" do
+      start_supervised!(SnowflakeConnection)
+
+      assert {:updated, 123} == SnowflakeConnection.execute("insert query", [])
     end
   end
 end


### PR DESCRIPTION
Enables insert queries.

The result of an insert is a tuple: `{:updated, [number of records inserted]}`

