### PR TITLE
Properly convert elixir nil to erlang :null in query params

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Fixed
+
+- Properly convert elixir nil to erlang :null in query params
+
 ## [0.4.1] - 2021-09-02
 
 ### Added

--- a/lib/snowflex/worker.ex
+++ b/lib/snowflex/worker.ex
@@ -164,10 +164,28 @@ defmodule Snowflex.Worker do
   end
 
   defp prepare_param({{type_atom, _size} = type, values}) when type_atom in @string_types do
-    {type, Enum.map(values, &to_charlist/1)}
+    {type, Enum.map(values, &null_or_charlist/1)}
   end
 
-  defp prepare_param(param), do: param
+  defp prepare_param({type, values}) do
+    {type, Enum.map(values, &null_or_any/1)}
+  end
+
+  defp null_or_charlist(nil) do
+    :null
+  end
+
+  defp null_or_charlist(val) do
+    to_charlist(val)
+  end
+
+  defp null_or_any(nil) do
+    :null
+  end
+
+  defp null_or_any(any) do
+    any
+  end
 
   defp send_heartbeat(state) do
     Logger.info("sending heartbeat")

--- a/test/snowflex/worker_test.exs
+++ b/test/snowflex/worker_test.exs
@@ -88,7 +88,7 @@ defmodule Snowflex.WorkerTest do
         end) =~ "sending heartbeat"
       )
 
-      assert :meck.num_calls(:odbc, :sql_query, ["mock pid", 'SELECT 1']) == 0
+      assert :meck.num_calls(:odbc, :param_query, ["mock pid", 'SELECT 1']) == 0
     end
   end
 

--- a/test/snowflex/worker_test.exs
+++ b/test/snowflex/worker_test.exs
@@ -34,7 +34,7 @@ defmodule Snowflex.WorkerTest do
     end
 
     test "does not send a heartbeat if `keep_alive?` is false" do
-      start_supervised!({Snowflex.Worker, @without_keep_alive})
+      start_supervised!({Worker, @without_keep_alive})
       Process.sleep(15)
 
       assert :meck.num_calls(:odbc, :sql_query, ["mock pid", 'SELECT 1']) == 0
@@ -42,7 +42,7 @@ defmodule Snowflex.WorkerTest do
 
     test "sends heartbeat every interval if `keep_alive?` is true" do
       assert capture_log(fn ->
-               start_supervised!({Snowflex.Worker, @with_keep_alive})
+               start_supervised!({Worker, @with_keep_alive})
                Process.sleep(30)
              end) =~ "sending heartbeat"
 
@@ -56,9 +56,9 @@ defmodule Snowflex.WorkerTest do
 
       refute(
         capture_log(fn ->
-          worker = start_supervised!({Snowflex.Worker, @with_keep_alive})
+          worker = start_supervised!({Worker, @with_keep_alive})
           Process.sleep(7)
-          Snowflex.Worker.sql_query(worker, "SELECT * FROM my_table")
+          Worker.sql_query(worker, "SELECT * FROM my_table")
           Process.sleep(7)
         end) =~ "sending heartbeat"
       )
@@ -75,10 +75,10 @@ defmodule Snowflex.WorkerTest do
 
       refute(
         capture_log(fn ->
-          worker = start_supervised!({Snowflex.Worker, @with_keep_alive})
+          worker = start_supervised!({Worker, @with_keep_alive})
           Process.sleep(7)
 
-          Snowflex.Worker.param_query(worker, "SELECT * FROM my_table WHERE name=?", [
+          Worker.param_query(worker, "SELECT * FROM my_table WHERE name=?", [
             Snowflex.string_param("dustin")
           ])
 
@@ -113,8 +113,8 @@ defmodule Snowflex.WorkerTest do
         {:selected, ['name'], [{'dustin'}]}
       end)
 
-      worker = start_supervised!({Snowflex.Worker, @with_keep_alive})
-      Snowflex.Worker.sql_query(worker, "SELECT * FROM my_table")
+      worker = start_supervised!({Worker, @with_keep_alive})
+      Worker.sql_query(worker, "SELECT * FROM my_table")
 
       assert_received {:event, [:snowflex, :sql_query, :start], %{system_time: _},
                        %{query: "SELECT * FROM my_table"}}


### PR DESCRIPTION
When performing inserts or updates, elixir nil values should be provided to :odbc as erlang :null.

Prior to this change, nils were going into snowflake as the string "null". 

