### PR TITLE
Call :erlang.garbage_collect/1 before the heartbeat if keep_alive? is true

### DIFF
--- a/lib/snowflex/worker.ex
+++ b/lib/snowflex/worker.ex
@@ -207,6 +207,7 @@ defmodule Snowflex.Worker do
 
   defp schedule_heartbeat(%{keep_alive?: true, heartbeat_interval: interval} = state) do
     Logger.info("scheduling next heartbeat in #{interval}ms")
+    :erlang.garbage_collect(self())
     ref = Process.send_after(self(), :send_heartbeat, interval)
     Map.put(state, :heartbeat_ref, ref)
   end


### PR DESCRIPTION
This is meant to address the worker building up a bunch of binary heap memory, but only as a stop gap until we have a better solution.