### PR TITLE
[WIP] Add a stream function to the api

### DIFF
--- a/lib/snowflex/connection.ex
+++ b/lib/snowflex/connection.ex
@@ -128,7 +128,8 @@ defmodule Snowflex.Connection do
         :poolboy.child_spec(@name, opts,
           connection_args: connection,
           keep_alive?: @keep_alive?,
-          heartbeat_interval: @heartbeat_interval
+          heartbeat_interval: @heartbeat_interval,
+          pool_name: @name
         )
       end
 
@@ -140,6 +141,16 @@ defmodule Snowflex.Connection do
       @impl Snowflex.Connection
       def execute(query, params) when is_binary(query) and is_list(params) do
         Snowflex.param_query(@name, query, params, @query_opts)
+      end
+
+      @impl Snowflex.Connection
+      def stream(query) when is_binary(query) do
+        Snowflex.stream(@name, query, @query_opts)
+      end
+
+      @impl Snowflex.Connection
+      def stream(query, fun) when is_binary(query) do
+        Snowflex.stream(@name, query, fun, @query_opts)
       end
     end
   end
@@ -157,4 +168,7 @@ defmodule Snowflex.Connection do
   """
   @callback execute(query :: String.t(), params :: list(Snowflex.query_param())) ::
               Snowflex.sql_data() | {:error, any} | {:updated, integer()}
+
+  @callback stream(query :: String.t(), function :: function()) :: Stream.t() | {:error, any}
+  @callback stream(query :: String.t()) :: Stream.t() | {:error, any}
 end

--- a/lib/snowflex/results.ex
+++ b/lib/snowflex/results.ex
@@ -1,0 +1,34 @@
+defmodule Snowflex.Results do
+  def process(data, opts) when is_list(data) do
+    Enum.map(data, &process(&1, opts))
+  end
+
+  def process({:selected, headers, rows}, opts) do
+    map_nulls_to_nil? = Keyword.get(opts, :map_nulls_to_nil?)
+
+    bin_headers =
+      headers
+      |> Enum.map(fn header -> header |> to_string() |> String.downcase() end)
+      |> Enum.with_index()
+
+    Enum.map(rows, fn row ->
+      Enum.reduce(bin_headers, %{}, fn {col, index}, map ->
+        data =
+          row
+          |> elem(index)
+          |> to_string_if_charlist()
+          |> map_null_to_nil(map_nulls_to_nil?)
+
+        Map.put(map, col, data)
+      end)
+    end)
+  end
+
+  def process({:updated, _} = results, _opts), do: results
+
+  defp to_string_if_charlist(data) when is_list(data), do: to_string(data)
+  defp to_string_if_charlist(data), do: data
+
+  defp map_null_to_nil(:null, true), do: nil
+  defp map_null_to_nil(data, _), do: data
+end


### PR DESCRIPTION
This function is build around [:odbc.select_count/3](https://www.erlang.org/doc/man/odbc.html#select_count-3) and the `next/0` function.

A stream is built using [Stream.resource/3](https://hexdocs.pm/elixir/Stream.html#resource/3) to do the following
1. call seect_count/3 to get a count and bind the query to the :odbc context
2. call next and process the data until the count is decremented to 0
3. upon :halt check the poolboy connection back in

This is all necessary because sufficiently large queries can cause very large spikes in memory.