### PR TITLE
Handle utf-16 encoding gracefully when querying Snowflake

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [0.5.1] - 2022-05-10
+
+### Added
+
+- Handle UTF-16 return data from Snowflake [#38](https://github.com/pepsico-ecommerce/snowflex/pull/38)
+
 ## [0.5.0] - 2022-01-19
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -92,7 +92,7 @@ The package can be installed by adding `snowflex` to your list of dependencies i
 ```elixir
 def deps do
   [
-    {:snowflex, "~> 0.4.4"}
+    {:snowflex, "~> 0.5.1"}
   ]
 end
 ```

--- a/lib/snowflex.ex
+++ b/lib/snowflex.ex
@@ -92,6 +92,7 @@ defmodule Snowflex do
         data =
           row
           |> elem(index)
+          |> handle_encoding()
           |> to_string_if_charlist()
           |> map_null_to_nil(map_nulls_to_nil?)
 
@@ -107,6 +108,17 @@ defmodule Snowflex do
 
   defp map_null_to_nil(:null, true), do: nil
   defp map_null_to_nil(data, _), do: data
+
+  defp handle_encoding(data) when is_list(data) do
+    raw = :erlang.list_to_binary(data)
+
+    case :unicode.characters_to_binary(raw) do
+      utf8 when is_binary(utf8) -> utf8
+      _ -> :unicode.characters_to_binary(raw, :latin1)
+    end
+  end
+
+  defp handle_encoding(data), do: data
 
   defp cast_row(row, schema) do
     schema

--- a/lib/snowflex/db_connection/result.ex
+++ b/lib/snowflex/db_connection/result.ex
@@ -44,6 +44,7 @@ defmodule Snowflex.DBConnection.Result do
         data =
           row
           |> elem(index)
+          |> handle_encoding()
           |> to_string_if_charlist()
           |> map_null_to_nil(map_nulls_to_nil?)
 
@@ -56,6 +57,17 @@ defmodule Snowflex.DBConnection.Result do
 
   defp to_string_if_charlist(data) when is_list(data), do: to_string(data)
   defp to_string_if_charlist(data), do: data
+
+  defp handle_encoding(data) when is_list(data) do
+    raw = :erlang.list_to_binary(data)
+
+    case :unicode.characters_to_binary(raw) do
+      utf8 when is_binary(utf8) -> utf8
+      _ -> :unicode.characters_to_binary(raw, :latin1)
+    end
+  end
+
+  defp handle_encoding(data), do: data
 
   defp map_null_to_nil(:null, true), do: nil
   defp map_null_to_nil(data, _), do: data

--- a/mix.exs
+++ b/mix.exs
@@ -4,7 +4,7 @@ defmodule Snowflex.MixProject do
   def project do
     [
       app: :snowflex,
-      version: "0.5.0",
+      version: "0.5.1",
       elixir: "~> 1.9",
       start_permanent: Mix.env() == :prod,
       deps: deps(),

--- a/test/snowflex/connection_test.exs
+++ b/test/snowflex/connection_test.exs
@@ -21,6 +21,10 @@ defmodule Snowflex.ConnectionTest do
       {:ok, %{}}
     end
 
+    def handle_call({:sql_query, "return_utf_16"}, _from, state) do
+      {:reply, {:ok, {:selected, ['col'], [{'CVS PharmacyÂ®'}]}}, state}
+    end
+
     def handle_call({:sql_query, "insert " <> _}, _from, state) do
       {:reply, {:ok, {:updated, 123}}, state}
     end
@@ -49,6 +53,13 @@ defmodule Snowflex.ConnectionTest do
       start_supervised!(SnowflakeConnection)
 
       assert {:updated, 123} == SnowflakeConnection.execute("insert query")
+    end
+
+    test "should execute a sql query with utf-16 artifacts and scrub it" do
+      start_supervised!(SnowflakeConnection)
+      # above we set this to return 'CVS PharmacyÂ®', as we saw in the real world, and then
+      # here we ensure that we just have the ® character
+      assert [%{"col" => "CVS Pharmacy®"}] == SnowflakeConnection.execute("return_utf_16")
     end
   end
 


### PR DESCRIPTION
This stemmed from an issue we saw in production, a result we were
getting included some garbled characters because of a UTF-8 and UTF-16
difference.

We were getting the string:

```
"CVS PharmacyÂ®"
```

Now, Â = U+00C2 and ® = U+00AE in UTF-8.

However, what we really wanted was:

```
"CVS Pharmacy®"
```

As the Â character is a mistaken extra byte.

Here, we introduce a function to properly handle this and return the
desired results using the latin1 encoding with UTF-8.

~~I have tried a couple ways of going about testing this, but the coverage
so far does not allow me an easy way to even hit this branch of the
functions in result or snowflex itself. I will confer with someone else
to get a real test written.~~

JIRA ticket is `AUTO-4025`

Here is validation run on this using just `iex` to demonstrate:

```elixir
iex(1)> string = "CVS PharmacyÂ®"
"CVS PharmacyÂ®"
iex(2)>
nil
iex(3)> defmodule Convert do
...(3)>   def parse(string) do
...(3)>     string
...(3)>     |> to_charlist
...(3)>     |> handle_encoding
...(3)>   end
...(3)>
...(3)>   defp handle_encoding(data) when is_list(data) do
...(3)>     raw = :erlang.list_to_binary(data)
...(3)>     case :unicode.characters_to_binary(raw) do
...(3)>       utf8 when is_binary(utf8) -> utf8
...(3)>       _ -> :unicode.characters_to_binary(raw, :latin1)
...(3)>     end
...(3)>   end
...(3)>
...(3)>   defp handle_encoding(data), do: data
...(3)> end
{:module, Convert,
 <<70, 79, 82, 49, 0, 0, 6, 240, 66, 69, 65, 77, 65, 116, 85, 56, 0, 0, 0, 236,
   0, 0, 0, 21, 14, 69, 108, 105, 120, 105, 114, 46, 67, 111, 110, 118, 101,
   114, 116, 8, 95, 95, 105, 110, 102, 111, 95, ...>>, {:handle_encoding, 1}}
iex(4)>
nil
iex(5)> IO.puts Convert.parse(string)
CVS Pharmacy®
:ok
```