### PR TITLE
ODBC error is not always a string

### DIFF
--- a/lib/snowflex/worker.ex
+++ b/lib/snowflex/worker.ex
@@ -82,7 +82,7 @@ defmodule Snowflex.Worker do
         {:noreply, state}
 
       {:error, reason} ->
-        Logger.warn("Unable to connect to snowflake: #{reason}")
+        Logger.warn("Unable to connect to snowflake: #{inspect(reason)}")
 
         Process.send_after(
           self(),
@@ -122,7 +122,7 @@ defmodule Snowflex.Worker do
   defp do_sql_query(%{pid: pid} = state, query) do
     case :odbc.sql_query(pid, to_charlist(query)) do
       {:error, reason} ->
-        Logger.warn("Unable to execute query: #{reason}")
+        Logger.warn("Unable to execute query: #{inspect(reason)}")
         {{:error, reason}, state}
 
       result ->
@@ -140,7 +140,7 @@ defmodule Snowflex.Worker do
 
     case :odbc.param_query(pid, ch_query, ch_params) do
       {:error, reason} ->
-        Logger.warn("Unable to execute query: #{reason}")
+        Logger.warn("Unable to execute query: #{inspect(reason)}")
         {{:error, reason}, state}
 
       result ->


### PR DESCRIPTION
`:odbc.connect` returns `{:error, Reason}`, but Reason isn't guaranteed
to be something that is stringable. A very common example would be
hitting the file/process limit on OSX, which throws {:emfile, [...]}.
This leads to the case statement throwing a ((Protocol.UndefinedError)
protocol String.Chars not implemented for...) which is a bit of a red
herring.

Tossing an inspect on the log line here would make it easier to debug
the underlying issue, especially the first time you come across it.

Closes #36