### PR TITLE
feat(snowflex): Add option to create migration for dynamic table

### DIFF
--- a/lib/snowflex/migration_generator.ex
+++ b/lib/snowflex/migration_generator.ex
@@ -6,40 +6,75 @@ defmodule Snowflex.MigrationGenerator do
   """
   defmacro generate_migrations(repo, modules) do
     quote bind_quoted: [repo: repo, modules: modules] do
-      for {module, index} <- Enum.with_index(modules) do
-        defmodule Module.concat(module, Migration) do
-          use Ecto.Migration
+      modules
+      |> Enum.with_index()
+      |> Enum.each(fn
+        {{module, {source, fields, primary_key}}, index} ->
+          defmodule Module.concat(module, Migration) do
+            use Ecto.Migration
 
-          @module module
+            @primary_key primary_key
+            @source source
+            @fields fields
 
-          def change do
-            primary_keys = @module.__schema__(:primary_key)
+            def change do
+              primary_keys = [@primary_key]
 
-            create table(@module.__schema__(:source), primary_key: false) do
-              for field <- @module.__schema__(:fields) do
-                type =
-                  :type
-                  |> @module.__schema__(field)
-                  |> ecto_type_to_db_type()
-
-                field_source = @module.__schema__(:field_source, field)
-                add(field_source, type, primary_key: field in primary_keys)
+              create table(@source, primary_key: false) do
+                for {name, type} <- @fields do
+                  field_type = ecto_type_to_db_type(type)
+                  field_source = name
+                  add(field_source, type, primary_key: name in primary_keys)
+                end
               end
             end
+
+            defp ecto_type_to_db_type({:parameterized, Ecto.Enum, _}), do: :string
+            defp ecto_type_to_db_type(any), do: any
           end
 
-          defp ecto_type_to_db_type({:parameterized, Ecto.Enum, _}), do: :string
-          defp ecto_type_to_db_type(any), do: any
-        end
+          Ecto.Migrator.up(
+            repo,
+            index,
+            Module.concat(module, Migration),
+            log: :info,
+            skip_table_creation: false
+          )
 
-        Ecto.Migrator.up(
-          repo,
-          index,
-          Module.concat(module, Migration),
-          log: :info,
-          skip_table_creation: false
-        )
-      end
+        {module, index} ->
+          defmodule Module.concat(module, Migration) do
+            use Ecto.Migration
+
+            @module module
+
+            def change do
+              primary_keys = @module.__schema__(:primary_key)
+
+              create table(@module.__schema__(:source), primary_key: false) do
+                for field <- @module.__schema__(:fields) do
+                  type =
+                    :type
+                    |> @module.__schema__(field)
+                    |> ecto_type_to_db_type()
+
+                  field_source = @module.__schema__(:field_source, field)
+                  add(field_source, type, primary_key: field in primary_keys)
+                end
+              end
+            end
+
+            defp ecto_type_to_db_type({:parameterized, Ecto.Enum, _}), do: :string
+            defp ecto_type_to_db_type(any), do: any
+          end
+
+          Ecto.Migrator.up(
+            repo,
+            index,
+            Module.concat(module, Migration),
+            log: :info,
+            skip_table_creation: false
+          )
+      end)
     end
   end
 end


### PR DESCRIPTION
- Support for creating test database which has no schema because is dynamic 
- In DPI we have clustering table which is dynamic, but the fields are same 

Example of such migration 
```
Snowflex.MigrationGenerator.generate_migrations(Snowflex.SQLiteTestRepo, [
  {CDNAClusteringTable,
   {"CDP.ANALYSIS.STAGE_CDNA_UI_CLUSTERING",
    [
      analysis_id: :integer,
      cv_living_unit_id: :integer,
      cluster_label: :integer,
      market: :string,
      dt_partition: :date
    ], []}}
])
```