### PR TITLE
build(deps): make sqlite3 opt-in

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,8 +168,15 @@ The largest difficulty with using another adapter is that there will be no
 migrations to get the test repo in a useable state for testing. This is solved
 by the `generate_migrations/2` macro in the `MigrationGenerator` module. The
 test repo must also be created and dropped before each run of the test suite to
-allow the generated migrations to run from a blank state. This can all be
-accomplished in the `test/test_helper.exs` file as follows:
+allow the generated migrations to run from a blank state. 
+
+Install `ecto_sqlite3` in `mix.exs`:
+
+```elixir
+      {:ecto_sqlite3, "~> 0.8", only: [:test]},
+```
+
+And update `test/test_helper.exs` file as follows:
 
 ```elixir
 require Snowflex.MigrationGenerator

--- a/mix.exs
+++ b/mix.exs
@@ -54,7 +54,7 @@ defmodule Snowflex.MixProject do
       {:dialyxir, "~> 1.0", only: :dev, runtime: false},
       {:ex_doc, ">= 0.0.0", only: :dev, runtime: false},
       {:meck, "~> 0.9", only: :test},
-      {:ecto_sqlite3, "~> 0.8.2"}
+      {:ecto_sqlite3, "~> 0.8.2", only: [:dev, :test]}
     ]
   end
 


### PR DESCRIPTION
Pinning sqlite3 to a specific version can break downstream applications in a way that is not strictly necessary.