### PR TITLE
refactor: only define test repo if sqlite3 is available

### DIFF
--- a/lib/snowflex/sqlite_test_repo.ex
+++ b/lib/snowflex/sqlite_test_repo.ex
@@ -1,5 +1,7 @@
-defmodule Snowflex.SQLiteTestRepo do
-  use Ecto.Repo,
-    otp_app: :snowflex,
-    adapter: Ecto.Adapters.SQLite3
+if Code.ensure_loaded?(Ecto.Adapters.SQLite3) do
+  defmodule Snowflex.SQLiteTestRepo do
+    use Ecto.Repo,
+      otp_app: :snowflex,
+      adapter: Ecto.Adapters.SQLite3
+  end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -54,7 +54,7 @@ defmodule Snowflex.MixProject do
       {:dialyxir, "~> 1.0", only: :dev, runtime: false},
       {:ex_doc, ">= 0.0.0", only: :dev, runtime: false},
       {:meck, "~> 0.9", only: :test},
-      {:ecto_sqlite3, "~> 0.8.2", only: [:dev, :test]}
+      {:ecto_sqlite3, "~> 0.8.2", optional: true, only: [:dev, :test]}
     ]
   end
 


### PR DESCRIPTION
This keeps the compiler happy if we're in a project or environment in which the user has chosen not to opt in to sqlite3 usage.