### PR TITLE
Update limit function to not match for QueryExpr

### DIFF
--- a/lib/snowflex/ecto/connection.ex
+++ b/lib/snowflex/ecto/connection.ex
@@ -536,7 +536,7 @@ defmodule Snowflex.EctoAdapter.Connection do
 
   defp limit(%{limit: nil}, _sources), do: []
 
-  defp limit(%{limit: %QueryExpr{expr: expr}} = query, sources) do
+  defp limit(%{limit: %{expr: expr}} = query, sources) do
     [" LIMIT " | expr(expr, sources, query)]
   end
 


### PR DESCRIPTION
- QueryExpr was [replaced](https://github.com/elixir-ecto/ecto/commit/ab0771ef7ea0825f0dadfe02bfbe04d946ca5f07#diff-f6fccb126b6a000082919ac48a91913684598c4a682e420bc4121c80b487c21cR2419) by LimitExpr in Ecto 3.10
- I removed the match for struct, same as [Postgrex Adapter](https://github.com/elixir-ecto/ecto_sql/blob/v3.10.0/lib/ecto/adapters/postgres/connection.ex#L604)