### PR TITLE
feat(ecto_adapter): cast maybe dates to date

### DIFF
--- a/lib/snowflex/ecto/ecto_adapter.ex
+++ b/lib/snowflex/ecto/ecto_adapter.ex
@@ -21,6 +21,9 @@ defmodule Snowflex.EctoAdapter do
   def loaders(:id, type), do: [&int_decode/1, type]
   def loaders(:time, type), do: [&time_decode/1, type]
   def loaders(:time_usec, type), do: [&time_decode/1, type]
+
+  # NB: Handles instances where date may be wrapped in an additional call, such as `Ecto.Query.API.max/1`
+  def loaders({:maybe, :date}, type), do: [&date_decode/1, type]
   def loaders(_, type), do: [type]
 
   def dumpers(:binary, type), do: [type, &binary_encode/1]

--- a/test/snowflex_ecto_adapter_test.exs
+++ b/test/snowflex_ecto_adapter_test.exs
@@ -1,0 +1,9 @@
+defmodule SnowflexEctoAdapterTest do
+  use ExUnit.Case
+
+  test "handles casting maybe date type to date" do
+    assert [date_decode, {:maybe, :date}] = Snowflex.EctoAdapter.loaders({:maybe, :date}, {:maybe, :date})
+    assert is_function(date_decode, 1)
+    assert {:ok, ~D[2023-10-23]} = date_decode.("2023-10-23")
+  end
+end

--- a/test/snowflex_sqlite_test.exs
+++ b/test/snowflex_sqlite_test.exs
@@ -7,7 +7,7 @@ defmodule SnowflexSqliteTest do
     :ok = Ecto.Adapters.SQL.Sandbox.checkout(Repo)
   end
 
-  test "can crete schema" do
+  test "can create schema" do
     Repo.insert!(%TestSchema{x: 1, y: 2, z: 3})
 
     assert [%TestSchema{x: 1, y: 2, z: 3}] = Repo.all(TestSchema)


### PR DESCRIPTION
Handles instances where date may be wrapped in an additional call, such as `Ecto.Query.API.max/1`.

Example:

```
from(s in MySchema, select_merge: %{my_date: max(s.my_date)})
|> MyRepo.all()
```