### PR TITLE
chore: use Ecto.Type.type to determine db type

### DIFF
--- a/lib/snowflex/ecto/connection.ex
+++ b/lib/snowflex/ecto/connection.ex
@@ -253,7 +253,7 @@ defmodule Snowflex.EctoAdapter.Connection do
 
   defp insert_all_value(nil), do: "DEFAULT"
   defp insert_all_value({%Ecto.Query{} = query, _params_counter}), do: [?(, all(query), ?)]
-  defp insert_all_value(_), do: '?'
+  defp insert_all_value(_), do: "?"
 
   @impl true
   def update(prefix, table, fields, filters, _returning) do
@@ -598,7 +598,7 @@ defmodule Snowflex.EctoAdapter.Connection do
   end
 
   defp expr({:^, [], [_ix]}, _sources, _query) do
-    '?'
+    "?"
   end
 
   defp expr({{:., _, [{:parent_as, _, [as]}, field]}, _, []}, _sources, query)

--- a/lib/snowflex/migration_generator.ex
+++ b/lib/snowflex/migration_generator.ex
@@ -22,15 +22,12 @@ defmodule Snowflex.MigrationGenerator do
 
               create table(@source, primary_key: false) do
                 for {name, type} <- @fields do
-                  field_type = ecto_type_to_db_type(type)
+                  field_type = Ecto.Type.type(type)
                   field_source = name
                   add(field_source, type, primary_key: name in primary_keys)
                 end
               end
             end
-
-            defp ecto_type_to_db_type({:parameterized, Ecto.Enum, _}), do: :string
-            defp ecto_type_to_db_type(any), do: any
           end
 
           Ecto.Migrator.up(
@@ -55,16 +52,13 @@ defmodule Snowflex.MigrationGenerator do
                   type =
                     :type
                     |> @module.__schema__(field)
-                    |> ecto_type_to_db_type()
+                    |> Ecto.Type.type()
 
                   field_source = @module.__schema__(:field_source, field)
                   add(field_source, type, primary_key: field in primary_keys)
                 end
               end
             end
-
-            defp ecto_type_to_db_type({:parameterized, Ecto.Enum, _}), do: :string
-            defp ecto_type_to_db_type(any), do: any
           end
 
           Ecto.Migrator.up(


### PR DESCRIPTION
## Context

ecto release v1.12.1 introduced a change to the way mappings were return for `Ecto.Enum.mappings/2`.

We were relying on this mapping to convert Ecto.Enum to `:string` when creating the database columns.

See https://github.com/elixir-ecto/ecto/commit/21c6068c9c829df13f4cb577cbd53263b4950262#diff-025069044568b480ef6f86f025cb46a7064695e6df1e7008ede689e09a9c7836L317-R318

## Decision

To make this more future proof, use `Ecto.Type.type/1` to handle schema type to database type conversions.

---

chore: fix single-quoted warning

## Context

```
warning: single-quoted strings represent charlists. Use ~c"" if you indeed want a charlist or use "" instead
     │
 256 │   defp insert_all_value(_), do: '?'
     │                                 ~
     │
     └─ lib/snowflex/ecto/connection.ex:256:33

     warning: single-quoted strings represent charlists. Use ~c"" if you indeed want a charlist or use "" instead
     │
 601 │     '?'
     │     ~
     │
     └─ lib/snowflex/ecto/connection.ex:601:5
```