### PR TITLE
Fix deprecation warnings for Logger

### DIFF
--- a/lib/snowflex/db_connection/server.ex
+++ b/lib/snowflex/db_connection/server.ex
@@ -104,7 +104,7 @@ defmodule Snowflex.DBConnection.Server do
       case :odbc.sql_query(pid, to_charlist(statement)) do
         {:error, reason} ->
           error = Error.exception(reason)
-          Logger.warn("Unable to execute query: #{error.message}")
+          Logger.warning("Unable to execute query: #{error.message}")
 
           {:reply, {:error, error}, state}
 
@@ -133,7 +133,7 @@ defmodule Snowflex.DBConnection.Server do
       case :odbc.param_query(pid, to_charlist(statement), params) do
         {:error, reason} ->
           error = Error.exception(reason)
-          Logger.warn("Unable to execute query: #{error.message}")
+          Logger.warning("Unable to execute query: #{error.message}")
 
           {:reply, {:error, error}, state}
 
@@ -161,7 +161,7 @@ defmodule Snowflex.DBConnection.Server do
         {:noreply, %{pid: pid, backoff: :backoff.succeed(backoff), state: :connected}}
 
       {:error, reason} ->
-        Logger.warn("Unable to connect to snowflake: #{inspect(reason)}")
+        Logger.warning("Unable to connect to snowflake: #{inspect(reason)}")
 
         seconds =
           backoff

--- a/lib/snowflex/worker.ex
+++ b/lib/snowflex/worker.ex
@@ -82,7 +82,7 @@ defmodule Snowflex.Worker do
         {:noreply, state}
 
       {:error, reason} ->
-        Logger.warn("Unable to connect to snowflake: #{inspect(reason)}")
+        Logger.warning("Unable to connect to snowflake: #{inspect(reason)}")
 
         Process.send_after(
           self(),
@@ -122,7 +122,7 @@ defmodule Snowflex.Worker do
   defp do_sql_query(%{pid: pid} = state, query) do
     case :odbc.sql_query(pid, to_charlist(query)) do
       {:error, reason} ->
-        Logger.warn("Unable to execute query: #{inspect(reason)}")
+        Logger.warning("Unable to execute query: #{inspect(reason)}")
         {{:error, reason}, state}
 
       result ->
@@ -140,7 +140,7 @@ defmodule Snowflex.Worker do
 
     case :odbc.param_query(pid, ch_query, ch_params) do
       {:error, reason} ->
-        Logger.warn("Unable to execute query: #{inspect(reason)}")
+        Logger.warning("Unable to execute query: #{inspect(reason)}")
         {{:error, reason}, state}
 
       result ->
@@ -162,7 +162,7 @@ defmodule Snowflex.Worker do
   end
 
   defp log_heartbeat_result({{:error, _reason}, state}) do
-    Logger.warn("heartbeat failed to send")
+    Logger.warning("heartbeat failed to send")
     state
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -9,7 +9,7 @@ defmodule Snowflex.MixProject do
       app: :snowflex,
       name: "Snowflex",
       version: @version,
-      elixir: "~> 1.9",
+      elixir: "~> 1.11",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       package: package(),


### PR DESCRIPTION
`Logger.warn/1` has been deprecated for a long time in favor of `Logger.warning/1`. This fixes those compiler warnings along with bumping the minimum Elixir version to 1.11. Given the Elixir community only really supports the previous two minor versions of Elixir this shouldn't be a big deal for users.