### PR TITLE
fix(snowflex): add float_decode for Decimal

### DIFF
--- a/lib/snowflex.ex
+++ b/lib/snowflex.ex
@@ -79,6 +79,7 @@ defmodule Snowflex do
 
   defp float_decode(nil), do: {:ok, nil}
   defp float_decode(float) when is_float(float), do: float
+  defp float_decode(%Decimal{} = decimal), do: {:ok, Decimal.to_float(decimal)}
 
   defp float_decode(float) do
     {val, _} = Float.parse(float)


### PR DESCRIPTION
`fixed` data on Snowflake is parsed by our http connector as a Decimal type.
If a user of the library declares that data as a `float` in their schema this will lead to a crash as there's no appropriate function to handle this data mismatch.

We elect here to autmatically convert the Decimal type to a float for the user following the convention set forth in the MyXQL Ecto adapter here:
https://github.com/elixir-ecto/ecto_sql/blame/aa9a3291f785522d24d9f1571d2aa79acbe0d2e5/lib/ecto/adapters/myxql.ex#L178