### PR TITLE
fix: change from literal to identifier.

### DIFF
--- a/lib/snowflex/ecto/adapter/connection.ex
+++ b/lib/snowflex/ecto/adapter/connection.ex
@@ -733,7 +733,7 @@ defmodule Snowflex.Ecto.Adapter.Connection do
     |> parens_for_select()
   end
 
-  defp expr({:literal, _, [literal]}, _sources, _query) do
+  defp expr({:identifier, _, [literal]}, _sources, _query) do
     quote_name(literal)
   end
 

--- a/test/snowflex/ecto/adapter/connection_test.exs
+++ b/test/snowflex/ecto/adapter/connection_test.exs
@@ -557,7 +557,7 @@ defmodule Snowflex.Ecto.Adapter.ConnectionTest do
     query =
       TestSchema |> select([r], fragment("? COLLATE ?", r.x, identifier(^"es_ES"))) |> plan()
 
-    assert all(query) == ~s{SELECT s0.x COLLATE identifier('es_ES') FROM schema AS s0}
+    assert all(query) == ~s{SELECT s0.x COLLATE es_ES FROM schema AS s0}
 
     value = 13
     query = TestSchema |> select([r], fragment("lcase(?, ?)", r.x, ^value)) |> plan()


### PR DESCRIPTION
internally [ecto replaces literal with identifier](https://github.com/elixir-ecto/ecto/blob/3b2d0062c2656b3ecfc1a9d0795acc427317e22a/lib/ecto/query/builder.ex\#L756-L769)