### PR TITLE
handle Date types in date_decode

### DIFF
--- a/lib/snowflex.ex
+++ b/lib/snowflex.ex
@@ -87,6 +87,7 @@ defmodule Snowflex do
   end
 
   defp date_decode(nil), do: {:ok, nil}
+  defp date_decode(%Date{} = date), do: {:ok, date}
   defp date_decode(date), do: Date.from_iso8601(date)
 
   ## Query


### PR DESCRIPTION
- `date_decode` does not know how to handle Date types and assumes everything will be of type binary.
- This is not true when wrapping a Date type in `max` or `min`.
- To solve for this, we anticipate the Date type and handle it appropriately