### PR TITLE
feat(http): support multiple return values

### DIFF
--- a/README.md
+++ b/README.md
@@ -112,6 +112,24 @@ The adapter supports the following type conversions:
 
 Snowflex does not support multi-statement transactions. The reason for this is the [Snowflake SQL API](https://docs.snowflake.com/en/developer-guide/sql-api/submitting-multiple-statements) does not support multi-request transactions. That is to say, all statements in a transaction _must_ be sent in the same request. Because it is a common pattern to rely on the results of a previous statement in further downstream queries in the same transaction (e.g. `Ecto.Multi`), this limitation in the SQL API meant that we either needed to provide a potentially unintuitive use case, or just not support them at all.
 
+### Multiple Statements
+
+Snowflex supports submitting multiple statements in the same query and will return the results of each statement packed into an array.  
+
+This can be useful when statements you want to execute need to occur inside of the same transaction (e.g. you need to leverage a temporary table)
+This is possible using both the `query` and `query_many` functions.
+
+``` elixir
+iex> Repo.query("SELECT 1; SELECT 2;")
+
+{:ok,
+ [
+   %Snowflex.Result{rows: [[1]]},
+   %Snowflex.Result{rows: [[2]]}
+ ]
+}
+```
+
 ### Streaming
 
 When streaming rows using `Snowflex.Transport.Http`, keep in mind that [Snowflake dictates the number of partitions returned](https://docs.snowflake.com/en/developer-guide/sql-api/handling-responses#retrieving-additional-partitions). This is different than a normal TCP protocol like `Postgrex`, where the stream will be iterating on one row at a time.

--- a/lib/snowflex/ecto/adapter/connection.ex
+++ b/lib/snowflex/ecto/adapter/connection.ex
@@ -25,8 +25,16 @@ defmodule Snowflex.Ecto.Adapter.Connection do
     conn
     |> DBConnection.execute(query, params, opts)
     |> then(fn
-      {:ok, _query, result} -> {:ok, result}
-      any -> any
+      {:ok, query, results} when is_list(results) ->
+        # DBConnection.execute automatically decodes if there is an implementation of the protocol,
+        # but since we have a list, we need to decode each result individually
+        {:ok, Enum.map(results, fn result -> DBConnection.Query.decode(query, result, opts) end)}
+
+      {:ok, _query, result} ->
+        {:ok, result}
+
+      any ->
+        any
     end)
   end
 

--- a/lib/snowflex/transport/http.ex
+++ b/lib/snowflex/transport/http.ex
@@ -299,6 +299,36 @@ defmodule Snowflex.Transport.Http do
 
   defp await_async_execution(_state, _status, body), do: {:ok, body}
 
+  defp gather_results(state, %{"statementHandles" => statement_handles}, opts) do
+    max_concurrency = System.schedulers_online()
+    extended_timeout = opts[:timeout] + :timer.seconds(30)
+
+    Task.Supervisor.async_stream_nolink(
+      Snowflex.TaskSupervisor,
+      statement_handles,
+      fn handle ->
+        case await_async_execution(state, 202, %{"statementHandle" => handle}) do
+          {:ok, body} -> gather_results(state, body, opts)
+          {:error, error} -> {:error, error}
+        end
+      end,
+      max_concurrency: max_concurrency,
+      ordered: true,
+      timeout: extended_timeout,
+      on_timeout: :kill_task
+    )
+    |> Enum.reduce_while({:ok, []}, fn
+      {:ok, {:ok, result_body}}, {:ok, acc} ->
+        {:cont, {:ok, acc ++ [{:ok, result_body}]}}
+
+      {:ok, {:error, error}}, _acc ->
+        {:halt, {:error, error}}
+
+      {:exit, reason}, _acc ->
+        {:halt, {:error, %Error{message: "Task failed: #{inspect(reason)}"}}}
+    end)
+  end
+
   defp gather_results(
          state,
          %{
@@ -499,6 +529,10 @@ defmodule Snowflex.Transport.Http do
     capped_delay = min(exponential_delay, max_delay)
     jitter = :rand.uniform() * 0.1 * capped_delay
     trunc(capped_delay + jitter)
+  end
+
+  defp format_response_body(body) when is_list(body) do
+    Enum.map(body, fn {:ok, statement_body} -> format_response_body(statement_body) end)
   end
 
   defp format_response_body(body) do


### PR DESCRIPTION
We now support an http query which contains multiple statements returning multiple results.
The results are returned as a list of `Snowflex.Result` values for both `query` and `query_many` calls which results in multiple responses.