### PR TITLE
Support custom fullsweep_after

### DIFF
--- a/lib/snowflex/transport/http.ex
+++ b/lib/snowflex/transport/http.ex
@@ -264,7 +264,7 @@ defmodule Snowflex.Transport.Http do
   @impl GenServer
   def init(opts) do
     if fullsweep_after = Keyword.get(opts, :fullsweep_after) do
-      _ = :erlang.process_flag(:fullsweep_after, fullsweep_after)
+      _ = Process.flag(:fullsweep_after, fullsweep_after)
       :ok
     end
 

--- a/lib/snowflex/transport/http.ex
+++ b/lib/snowflex/transport/http.ex
@@ -264,7 +264,8 @@ defmodule Snowflex.Transport.Http do
   @impl GenServer
   def init(opts) do
     if fullsweep_after = Keyword.get(opts, :fullsweep_after) do
-      :erlang.process_flag(:fullsweep_after, fullsweep_after)
+      _ = :erlang.process_flag(:fullsweep_after, fullsweep_after)
+      :ok
     end
 
     with {:ok, validated_opts, private_key} <- validate_and_read_private_key(opts),

--- a/lib/snowflex/transport/http.ex
+++ b/lib/snowflex/transport/http.ex
@@ -28,6 +28,7 @@ defmodule Snowflex.Transport.Http do
   * `:retry_max_delay` - Maximum delay between retries in milliseconds (default: 8000)
   * `:connect_options` - Connection options for Finch pool configuration
   * `:req_options` - Additional options to pass to `Req.new/1` (e.g., `:plug` for testing)
+  * `:fullsweep_after` - Sets the `fullsweep_after` garbage collection flag on the process (default: ERTS default)
 
   ## Account Name Handling
 
@@ -262,6 +263,10 @@ defmodule Snowflex.Transport.Http do
 
   @impl GenServer
   def init(opts) do
+    if fullsweep_after = Keyword.get(opts, :fullsweep_after) do
+      :erlang.process_flag(:fullsweep_after, fullsweep_after)
+    end
+
     with {:ok, validated_opts, private_key} <- validate_and_read_private_key(opts),
          {:ok, state} <- init_state(validated_opts, private_key) do
       check_connection(state)

--- a/test/transport/http_test.exs
+++ b/test/transport/http_test.exs
@@ -1,8 +1,10 @@
 defmodule Snowflex.Transport.HttpTest do
   use ExUnit.Case
 
+  alias Req.Test, as: ReqTest
   alias Snowflex.Error
   alias Snowflex.Transport.Http
+  alias Snowflex.Transport.HttpTest.FullsweepPlug
 
   defmodule DummyHttp do
     use GenServer
@@ -35,10 +37,10 @@ defmodule Snowflex.Transport.HttpTest do
 
   describe "fullsweep_after option" do
     setup do
-      Req.Test.set_req_test_to_shared(%{})
+      ReqTest.set_req_test_to_shared(%{})
 
-      Req.Test.stub(Snowflex.Transport.HttpTest.FullsweepPlug, fn conn ->
-        Req.Test.json(conn, %{})
+      ReqTest.stub(FullsweepPlug, fn conn ->
+        ReqTest.json(conn, %{})
       end)
 
       :ok
@@ -49,7 +51,7 @@ defmodule Snowflex.Transport.HttpTest do
       username: "test_user",
       public_key_fingerprint: "test_fingerprint",
       private_key_path: Path.join(File.cwd!(), "test/fixtures/fake_private_key.pem"),
-      req_options: [plug: {Req.Test, Snowflex.Transport.HttpTest.FullsweepPlug}]
+      req_options: [plug: {ReqTest, FullsweepPlug}]
     ]
 
     test "sets process flag when fullsweep_after is provided" do

--- a/test/transport/http_test.exs
+++ b/test/transport/http_test.exs
@@ -58,7 +58,7 @@ defmodule Snowflex.Transport.HttpTest do
       opts = @fullsweep_opts ++ [fullsweep_after: 0]
       {:ok, pid} = Http.start_link(opts)
 
-      {:garbage_collection, gc_info} = :erlang.process_info(pid, :garbage_collection)
+      {:garbage_collection, gc_info} = Process.info(pid, :garbage_collection)
       assert gc_info[:fullsweep_after] == 0
 
       GenServer.stop(pid)
@@ -67,7 +67,7 @@ defmodule Snowflex.Transport.HttpTest do
     test "leaves default when fullsweep_after is not provided" do
       {:ok, pid} = Http.start_link(@fullsweep_opts)
 
-      {:garbage_collection, gc_info} = :erlang.process_info(pid, :garbage_collection)
+      {:garbage_collection, gc_info} = Process.info(pid, :garbage_collection)
       assert gc_info[:fullsweep_after] > 0
 
       GenServer.stop(pid)

--- a/test/transport/http_test.exs
+++ b/test/transport/http_test.exs
@@ -33,6 +33,45 @@ defmodule Snowflex.Transport.HttpTest do
     assert %{} = Http.execute_statement(pid, nil, nil, timeout: 1000)
   end
 
+  describe "fullsweep_after option" do
+    setup do
+      Req.Test.set_req_test_to_shared(%{})
+
+      Req.Test.stub(Snowflex.Transport.HttpTest.FullsweepPlug, fn conn ->
+        Req.Test.json(conn, %{})
+      end)
+
+      :ok
+    end
+
+    @fullsweep_opts [
+      account_name: "test-account",
+      username: "test_user",
+      public_key_fingerprint: "test_fingerprint",
+      private_key_path: Path.join(File.cwd!(), "test/fixtures/fake_private_key.pem"),
+      req_options: [plug: {Req.Test, Snowflex.Transport.HttpTest.FullsweepPlug}]
+    ]
+
+    test "sets process flag when fullsweep_after is provided" do
+      opts = @fullsweep_opts ++ [fullsweep_after: 0]
+      {:ok, pid} = Http.start_link(opts)
+
+      {:garbage_collection, gc_info} = :erlang.process_info(pid, :garbage_collection)
+      assert gc_info[:fullsweep_after] == 0
+
+      GenServer.stop(pid)
+    end
+
+    test "leaves default when fullsweep_after is not provided" do
+      {:ok, pid} = Http.start_link(@fullsweep_opts)
+
+      {:garbage_collection, gc_info} = :erlang.process_info(pid, :garbage_collection)
+      assert gc_info[:fullsweep_after] > 0
+
+      GenServer.stop(pid)
+    end
+  end
+
   describe "private key configuration" do
     # Sample private key for testing (this is a dummy key generated for testing only)
     @test_private_key """


### PR DESCRIPTION
Hello!

With this PR `init/1` optionally calls `:erlang.process_flag(:fullsweep_after, n)` when the option is present  in opts.

This lets consumers force aggressive GC on long-lived pool workers that accumulate memory.

https://www.erlang.org/doc/apps/erts/erlang.html#spawn_opt/4

<img width="1275" height="299" alt="Screenshot 2026-02-25 at 22 42 02" src="https://github.com/user-attachments/assets/558aa028-7e99-485d-b806-87ea202191e1" />

I checked locally these processes have `{:fullsweep_after, 0}` if I pass that option on the snowflake opts.

What do you think?

Cheers,

Victor