### PR TITLE
chore: bump min elixir version to 1.15

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,9 +16,6 @@ jobs:
     strategy:
       matrix:
         include:
-          - elixir: 1.14.5
-            otp: 25.3
-            mix_check: ci
           - elixir: 1.15.7
             otp: 26.2
             mix_check: ci

--- a/mix.exs
+++ b/mix.exs
@@ -9,7 +9,7 @@ defmodule Snowflex.MixProject do
       app: :snowflex,
       name: "Snowflex",
       version: @version,
-      elixir: "~> 1.14",
+      elixir: "~> 1.15",
       start_permanent: Mix.env() == :prod,
       deps: deps(),
       package: package(),


### PR DESCRIPTION
Security support for Elixir 1.14 Ended 10/2025