### PR TITLE
fix: raise clear error for unsupported on_conflict modes

### DIFF
--- a/lib/snowflex/ecto/adapter/connection.ex
+++ b/lib/snowflex/ecto/adapter/connection.ex
@@ -208,29 +208,11 @@ defmodule Snowflex.Ecto.Adapter.Connection do
     []
   end
 
-  defp on_conflict({:nothing, _, []}, [field | _]) do
-    quoted = quote_name(field)
-    [" ON DUPLICATE KEY UPDATE ", quoted, " = " | quoted]
-  end
-
-  defp on_conflict({fields, _, []}, _header) when is_list(fields) do
-    [
-      " ON DUPLICATE KEY UPDATE "
-      | intersperse_map(fields, ?,, fn field ->
-          quoted = quote_name(field)
-          [quoted, " = VALUES(", quoted, ?)]
-        end)
-    ]
-  end
-
-  defp on_conflict({%{wheres: []} = query, _, []}, _header) do
-    [" ON DUPLICATE KEY " | update_all(query, "UPDATE ")]
-  end
-
-  defp on_conflict({_query, _, []}, _header) do
+  defp on_conflict({_, _, []}, _header) do
     error!(
       nil,
-      "Using a query with :where in combination with the :on_conflict option is not supported by Snowflake"
+      ":on_conflict is not supported by Snowflake's INSERT statement. " <>
+        "Use a MERGE INTO statement via raw SQL for upserts."
     )
   end
 

--- a/test/snowflex/ecto/adapter/connection_test.exs
+++ b/test/snowflex/ecto/adapter/connection_test.exs
@@ -1242,37 +1242,49 @@ defmodule Snowflex.Ecto.Adapter.ConnectionTest do
                  end
   end
 
-  test "insert with on duplicate key" do
-    query = insert(nil, "schema", [:x, :y], [[:x, :y]], {:nothing, [], []}, [])
+  test "insert with on_conflict" do
+    # :on_conflict :raise is the only supported mode — it emits no extra SQL.
+    query = insert(nil, "schema", [:x, :y], [[:x, :y]], {:raise, [], []}, [])
+    assert query == ~s{INSERT INTO schema (x,y) VALUES (?,?)}
 
-    assert query ==
-             ~s{INSERT INTO schema (x,y) VALUES (?,?) ON DUPLICATE KEY UPDATE x = x}
-
-    update = from("schema", update: [set: [z: "foo"]]) |> plan(:update_all)
-    query = insert(nil, "schema", [:x, :y], [[:x, :y]], {update, [], []}, [])
-
-    assert query ==
-             ~s{INSERT INTO schema (x,y) VALUES (?,?) ON DUPLICATE KEY UPDATE z = 'foo'}
-
-    query = insert(nil, "schema", [:x, :y], [[:x, :y]], {[:x, :y], [], []}, [])
-
-    assert query ==
-             ~s{INSERT INTO schema (x,y) VALUES (?,?) ON DUPLICATE KEY UPDATE x = VALUES(x),y = VALUES(y)}
-
+    # :on_conflict :nothing must raise — Snowflake INSERT has no ON CONFLICT clause.
     assert_raise ArgumentError,
-                 ":conflict_target is not supported in insert/insert_all by Snowflake",
+                 ~r/:on_conflict is not supported by Snowflake.*MERGE/,
                  fn ->
-                   insert(nil, "schema", [:x, :y], [[:x, :y]], {[:x, :y], [], [:x]}, [])
+                   insert(nil, "schema", [:x, :y], [[:x, :y]], {:nothing, [], []}, [])
                  end
 
+    # :on_conflict with a list of replace fields must raise.
     assert_raise ArgumentError,
-                 "Using a query with :where in combination with the :on_conflict option is not supported by Snowflake",
+                 ~r/:on_conflict is not supported by Snowflake.*MERGE/,
+                 fn ->
+                   insert(nil, "schema", [:x, :y], [[:x, :y]], {[:x, :y], [], []}, [])
+                 end
+
+    # :on_conflict with an update query (no where) must raise.
+    assert_raise ArgumentError,
+                 ~r/:on_conflict is not supported by Snowflake.*MERGE/,
+                 fn ->
+                   update = from("schema", update: [set: [z: "foo"]]) |> plan(:update_all)
+                   insert(nil, "schema", [:x, :y], [[:x, :y]], {update, [], []}, [])
+                 end
+
+    # :on_conflict with an update query that has a where must raise.
+    assert_raise ArgumentError,
+                 ~r/:on_conflict is not supported by Snowflake.*MERGE/,
                  fn ->
                    update =
                      from("schema", update: [set: [x: ^"foo"]], where: [z: "bar"])
                      |> plan(:update_all)
 
                    insert(nil, "schema", [:x, :y], [[:x, :y]], {update, [], []}, [])
+                 end
+
+    # :conflict_target is still rejected with its existing message.
+    assert_raise ArgumentError,
+                 ":conflict_target is not supported in insert/insert_all by Snowflake",
+                 fn ->
+                   insert(nil, "schema", [:x, :y], [[:x, :y]], {[:x, :y], [], [:x]}, [])
                  end
   end
 


### PR DESCRIPTION
## Summary

- `Snowflex.Ecto.Adapter.Connection.on_conflict/2` emitted MySQL-flavored `ON DUPLICATE KEY UPDATE` syntax, which Snowflake does not support. Any `Repo.insert/2` call with `on_conflict: :nothing` or `on_conflict: [fields]` would generate invalid SQL that Snowflake rejects.
- Snowflake's `INSERT` has no `ON CONFLICT` clause — upserts require `MERGE INTO`. Until MERGE support lands as its own feature, raise a clear `ArgumentError` pointing users at MERGE instead of silently producing broken SQL.
- `on_conflict: :raise` is unchanged.

## Test plan

- [x] Unit tests rewritten to assert the new error across all five `on_conflict` modes (`:raise`, `:nothing`, list of replace fields, update query without `where`, update query with `where`); pre-existing `:conflict_target` rejection still verified.
- [x] `mix test test/snowflex/ecto/adapter/connection_test.exs` — 79 passed.
- [ ] Integration tests against a live Snowflake account (require credentials not available locally).