### PR TITLE
feat: implement aggregate filter() via CASE WHEN translation

### DIFF
--- a/lib/snowflex/ecto/adapter/connection.ex
+++ b/lib/snowflex/ecto/adapter/connection.ex
@@ -678,8 +678,24 @@ defmodule Snowflex.Ecto.Adapter.Connection do
     ["NOT (", expr(expr, sources, query), ?)]
   end
 
+  defp expr({:filter, _, [{:count, _, []}, cond]}, sources, query) do
+    ["COUNT_IF(", expr(cond, sources, query), ")"]
+  end
+
+  defp expr({:filter, _, [{agg, _, [arg]}, cond]}, sources, query)
+       when agg in [:count, :sum, :avg, :min, :max] do
+    [
+      Atom.to_string(agg),
+      "(CASE WHEN ",
+      expr(cond, sources, query),
+      " THEN ",
+      expr(arg, sources, query),
+      " END)"
+    ]
+  end
+
   defp expr({:filter, _, _}, _sources, query) do
-    error!(query, "Snowflake adapter does not support aggregate filters")
+    error!(query, "Snowflake adapter does not support filter() on this aggregate")
   end
 
   defp expr(%Ecto.SubQuery{query: query}, sources, parent_query) do

--- a/test/snowflex/ecto/adapter/connection_test.exs
+++ b/test/snowflex/ecto/adapter/connection_test.exs
@@ -298,11 +298,52 @@ defmodule Snowflex.Ecto.Adapter.ConnectionTest do
     assert all(query) == ~s{SELECT count(*)::number FROM schema AS s0}
   end
 
-  test "aggregate filters" do
+  test "aggregate filters - count with field" do
     query = TestSchema |> select([r], count(r.x) |> filter(r.x > 10)) |> plan()
+    assert all(query) == ~s{SELECT count(CASE WHEN s0.x > 10 THEN s0.x END) FROM schema AS s0}
+  end
+
+  test "aggregate filters - count(*) uses COUNT_IF" do
+    query = TestSchema |> select([r], count() |> filter(r.x > 10)) |> plan()
+    assert all(query) == ~s{SELECT COUNT_IF(s0.x > 10) FROM schema AS s0}
+  end
+
+  test "aggregate filters - sum" do
+    query = TestSchema |> select([r], sum(r.x) |> filter(r.x > 10)) |> plan()
+    assert all(query) == ~s{SELECT sum(CASE WHEN s0.x > 10 THEN s0.x END) FROM schema AS s0}
+  end
+
+  test "aggregate filters - avg" do
+    query = TestSchema |> select([r], avg(r.x) |> filter(r.x > 10)) |> plan()
+    assert all(query) == ~s{SELECT avg(CASE WHEN s0.x > 10 THEN s0.x END) FROM schema AS s0}
+  end
+
+  test "aggregate filters - min" do
+    query = TestSchema |> select([r], min(r.x) |> filter(r.x > 10)) |> plan()
+    assert all(query) == ~s{SELECT min(CASE WHEN s0.x > 10 THEN s0.x END) FROM schema AS s0}
+  end
+
+  test "aggregate filters - max" do
+    query = TestSchema |> select([r], max(r.x) |> filter(r.x > 10)) |> plan()
+    assert all(query) == ~s{SELECT max(CASE WHEN s0.x > 10 THEN s0.x END) FROM schema AS s0}
+  end
+
+  test "aggregate filters - compound condition" do
+    query =
+      TestSchema |> select([r], count(r.x) |> filter(r.x > 0 and r.y < 100)) |> plan()
+
+    assert all(query) ==
+             ~s{SELECT count(CASE WHEN (s0.x > 0) AND (s0.y < 100) THEN s0.x END) FROM schema AS s0}
+  end
+
+  test "aggregate filters - unsupported aggregate raises" do
+    query =
+      TestSchema
+      |> select([r], fragment("bad_agg(?)", r.x) |> filter(r.x > 10))
+      |> plan()
 
     assert_raise Ecto.QueryError,
-                 ~r/Snowflake adapter does not support aggregate filters in query/,
+                 ~r/Snowflake adapter does not support filter\(\) on this aggregate/,
                  fn ->
                    all(query)
                  end


### PR DESCRIPTION
## Summary

- Ecto's `filter(aggregate, condition)` previously raised; now translates to Snowflake-native SQL.
- `count(x) |> filter(cond)`, `sum`, `avg`, `min`, `max` translate to `agg(CASE WHEN cond THEN x END)`.
- `count() |> filter(cond)` (COUNT(*)) maps to `COUNT_IF(cond)`.
- Unsupported aggregates inside `filter()` still raise.
- Snowflake does not natively support the SQL `FILTER (WHERE ...)` clause; this translation is the standard workaround.

## Test plan

- [x] Unit tests for count/sum/avg/min/max with filter()
- [x] count() with filter() emits COUNT_IF
- [x] Compound conditions inside filter()
- [x] Unsupported aggregates still raise
- [ ] Integration tests against live Snowflake (require credentials)