### PR TITLE
Bump version to 1.3.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Enhancements
 
-- Support routing Snowflake REST requests at a dedicated Finch pool. When a `:finch` instance is supplied via `:req_options`, `Snowflex.Transport.Http` now omits `:connect_options` so Req does not reject the request for setting both `:finch` and `:connect_options`. This lets callers point a warehouse at an explicitly-sized, isolated Finch pool.
+- Support routing Snowflake REST requests at a dedicated Finch pool. When a `:finch` instance is supplied via `:req_options`, `Snowflex.Transport.Http` now omits `:connect_options` so Req does not reject the request for setting both `:finch` and `:connect_options`. This lets callers point a warehouse at an explicitly-sized, isolated Finch pool. ([#174](https://github.com/pepsico-ecommerce/snowflex/pull/174))
 
 ## [1.3.0] - 2026-06-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Support routing Snowflake REST requests at a dedicated Finch pool. When a `:finch` instance is supplied via `:req_options`, `Snowflex.Transport.Http` now omits `:connect_options` so Req does not reject the request for setting both `:finch` and `:connect_options`. This lets callers point a warehouse at an explicitly-sized, isolated Finch pool. ([#174](https://github.com/pepsico-ecommerce/snowflex/pull/174))
 
+### Changed
+
+- Relax `ecto` and `ecto_sql` requirements from `~> 3.14` to `~> 3.13` so consumers can stay on the 3.13 series.
+
 ## [1.3.0] - 2026-06-08
 
 ### Enhancements

--- a/mix.exs
+++ b/mix.exs
@@ -63,8 +63,8 @@ defmodule Snowflex.MixProject do
     [
       {:backoff, "~> 1.1.6"},
       # Ecto/DBConnection
-      {:ecto, "~> 3.14"},
-      {:ecto_sql, "~> 3.14"},
+      {:ecto, "~> 3.13"},
+      {:ecto_sql, "~> 3.13"},
       {:db_connection, "~> 2.4"},
       # HTTP
       {:req, "~> 0.5"},

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Snowflex.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/pepsico-ecommerce/snowflex"
-  @version "1.3.0"
+  @version "1.3.1"
 
   def project do
     [


### PR DESCRIPTION
Bumps version to `1.3.1`, finalizes the CHANGELOG, and relaxes the ecto requirement.

### Changed
- `mix.exs`: `@version` 1.3.0 → 1.3.1
- `mix.exs`: relax `ecto` / `ecto_sql` from `~> 3.14` to `~> 3.13` so consumers can stay on the 3.13 series (lockfile unchanged at 3.14.0, still valid)
- `CHANGELOG.md`: link the 1.3.1 entry to #174 and note the ecto relaxation