### PR TITLE
Release 1.3.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.3.2] - 2026-06-15
+
 ### Bug Fixes
 
 - Recycle pool workers when their HTTP transport process dies. `Snowflex.Connection.connect/1` no longer calls `Process.flag(:trap_exit, true)`, so the link from worker → transport propagates death normally: when the transport crashes, the worker dies with it, the DBConnection pool starts a replacement, and the next query lands on a fresh transport instead of looping forever on `{:noproc, ...}` against a stale pid.

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Snowflex.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/pepsico-ecommerce/snowflex"
-  @version "1.3.1"
+  @version "1.3.2"
 
   def project do
     [


### PR DESCRIPTION
## Summary

- Bumps version to `1.3.2` in `mix.exs`
- Promotes the `[Unreleased]` changelog entry to `[1.3.2] - 2026-06-15`

## Changes in this release

**Bug Fix:** Recycle pool workers when their HTTP transport process dies. `Snowflex.Connection.connect/1` no longer calls `Process.flag(:trap_exit, true)`, so the link from worker → transport propagates death normally: when the transport crashes, the worker dies with it, the DBConnection pool starts a replacement, and the next query lands on a fresh transport instead of looping forever on `{:noproc, ...}` against a stale pid.

## Test plan

- [ ] CI passes (existing connection/pool tests cover the recycling behaviour)
- [ ] After merge, tag `v1.3.2` on master and create the GitHub release