### PR TITLE
Use documented PARSE_JSON path for variant writes (update, update_all)

### DIFF
--- a/lib/snowflex.ex
+++ b/lib/snowflex.ex
@@ -19,6 +19,7 @@ defmodule Snowflex do
   alias Ecto.UUID
   alias Snowflex.Ecto.Adapter.Stream, as: AdapterStream
   alias Snowflex.Query
+  alias Snowflex.VariantField
   alias String.Chars
 
   require Logger
@@ -205,23 +206,21 @@ defmodule Snowflex do
     )
   end
 
+  defp json_fields_from_schema_meta(%{schema: nil}), do: []
+
   defp json_fields_from_schema_meta(%{schema: schema}) do
     Enum.filter(schema.__schema__(:fields), fn field ->
-      case schema.__schema__(:type, field) do
-        :map -> true
-        {:map, _} -> true
-        {:array, _} -> true
-        _other -> false
-      end
+      schema.__schema__(:type, field) |> VariantField.variant_field?()
     end)
   end
 
   @impl Ecto.Adapter.Schema
   def update(adapter_meta, schema_meta, fields, params, returning, opts) do
     %{source: source, prefix: prefix} = schema_meta
-    {fields, field_values} = :lists.unzip(fields)
+    {field_names, field_values} = :lists.unzip(fields)
     filter_values = Keyword.values(params)
-    sql = @conn.update(prefix, source, fields, params, returning)
+    json_fields = json_fields_from_schema_meta(schema_meta)
+    sql = @conn.update(prefix, source, field_names, params, returning, json_fields: json_fields)
 
     SQL.struct(
       adapter_meta,

--- a/lib/snowflex/ecto/adapter/connection.ex
+++ b/lib/snowflex/ecto/adapter/connection.ex
@@ -6,6 +6,7 @@ defmodule Snowflex.Ecto.Adapter.Connection do
 
   alias Ecto.Query.{BooleanExpr, ByExpr, JoinExpr, QueryExpr, WithExpr}
   alias Snowflex.Query
+  alias Snowflex.VariantField
 
   @impl Ecto.Adapters.SQL.Connection
   def child_spec(opts) do
@@ -220,6 +221,7 @@ defmodule Snowflex.Ecto.Adapter.Connection do
   defp insert_all(rows, header, json_fields)
 
   defp insert_all([], _header, _), do: []
+
   defp insert_all([_ | _] = rows, _header, []) do
     [
       "VALUES ",
@@ -261,8 +263,19 @@ defmodule Snowflex.Ecto.Adapter.Connection do
   end
 
   @impl Ecto.Adapters.SQL.Connection
-  def update(prefix, table, fields, filters, _returning) do
-    fields = intersperse_map(fields, ", ", &[quote_name(&1), " = ?"])
+  def update(prefix, table, fields, filters, returning, opts \\ [])
+
+  def update(prefix, table, fields, filters, _returning, opts) do
+    json_fields = Keyword.get(opts, :json_fields, [])
+
+    set_fields =
+      intersperse_map(fields, ", ", fn field ->
+        if field in json_fields do
+          [quote_name(field), " = PARSE_JSON(?)"]
+        else
+          [quote_name(field), " = ?"]
+        end
+      end)
 
     filters =
       intersperse_map(filters, " AND ", fn
@@ -273,7 +286,7 @@ defmodule Snowflex.Ecto.Adapter.Connection do
           [quote_name(field), " = ?"]
       end)
 
-    ["UPDATE ", quote_table(prefix, table), " SET ", fields, " WHERE " | filters]
+    ["UPDATE ", quote_table(prefix, table), " SET ", set_fields, " WHERE " | filters]
   end
 
   @impl Ecto.Adapters.SQL.Connection
@@ -426,16 +439,35 @@ defmodule Snowflex.Ecto.Adapter.Connection do
   end
 
   defp update_fields(type, %{updates: updates} = query, sources) do
+    variant_fields = variant_fields_from_query(query)
+
     fields =
       for(
         %{expr: expr} <- updates,
         {op, kw} <- expr,
         {key, value} <- kw,
-        do: update_op(op, update_key(type, key, query, sources), value, sources, query)
+        do:
+          update_op(
+            op,
+            update_key(type, key, query, sources),
+            value,
+            sources,
+            query,
+            key in variant_fields
+          )
       )
 
     Enum.intersperse(fields, ", ")
   end
+
+  defp variant_fields_from_query(%{from: %{source: {_table, schema}}})
+       when not is_nil(schema) do
+    Enum.filter(schema.__schema__(:fields), fn field ->
+      schema.__schema__(:type, field) |> VariantField.variant_field?()
+    end)
+  end
+
+  defp variant_fields_from_query(_query), do: []
 
   defp update_key(:update, key, %{from: from} = query, sources) do
     {_from, name} = get_source(query, sources, 0, from)
@@ -447,15 +479,19 @@ defmodule Snowflex.Ecto.Adapter.Connection do
     quote_name(key)
   end
 
-  defp update_op(:set, quoted_key, value, sources, query) do
+  defp update_op(:set, quoted_key, value, sources, query, true) do
+    [quoted_key, " = PARSE_JSON(", expr(value, sources, query), ")"]
+  end
+
+  defp update_op(:set, quoted_key, value, sources, query, _not_variant) do
     [quoted_key, " = " | expr(value, sources, query)]
   end
 
-  defp update_op(:inc, quoted_key, value, sources, query) do
+  defp update_op(:inc, quoted_key, value, sources, query, _variant) do
     [quoted_key, " = ", quoted_key, " + " | expr(value, sources, query)]
   end
 
-  defp update_op(command, _quoted_key, _value, _sources, query) do
+  defp update_op(command, _quoted_key, _value, _sources, query, _variant) do
     error!(query, "Unknown update operation #{inspect(command)} for Snowflake")
   end
 

--- a/lib/snowflex/variant_field.ex
+++ b/lib/snowflex/variant_field.ex
@@ -1,0 +1,34 @@
+defmodule Snowflex.VariantField do
+  @moduledoc """
+  Shared predicate for identifying Ecto field types that map to Snowflake's
+  VARIANT semi-structured type (`:map`, `{:map, _}`, `{:array, _}`).
+
+  This is the single source of truth used by both `Snowflex` (for insert/update
+  via schema meta) and `Snowflex.Ecto.Adapter.Connection` (for update_all SQL
+  generation).
+  """
+
+  @doc """
+  Returns `true` if the given Ecto field type maps to a Snowflake VARIANT column.
+
+  ## Examples
+
+      iex> Snowflex.VariantField.variant_field?(:map)
+      true
+
+      iex> Snowflex.VariantField.variant_field?({:map, :string})
+      true
+
+      iex> Snowflex.VariantField.variant_field?({:array, :integer})
+      true
+
+      iex> Snowflex.VariantField.variant_field?(:string)
+      false
+
+  """
+  @spec variant_field?(term()) :: boolean()
+  def variant_field?(:map), do: true
+  def variant_field?({:map, _}), do: true
+  def variant_field?({:array, _}), do: true
+  def variant_field?(_), do: false
+end

--- a/test/integration/variant_integration_test.exs
+++ b/test/integration/variant_integration_test.exs
@@ -1,6 +1,8 @@
 defmodule Snowflex.VariantIntegrationTest do
   use ExUnit.Case, async: false
 
+  alias Ecto.Changeset
+
   @moduletag :integration
 
   defmodule SnowflexTestMapSchema do
@@ -20,6 +22,16 @@ defmodule Snowflex.VariantIntegrationTest do
       field :names, {:array, :string}
       field :ages, {:array, :integer}
       field :things, {:array, :map}
+    end
+  end
+
+  defmodule SnowflexTestMixedSchema do
+    use Ecto.Schema
+
+    @primary_key {:id, :string, []}
+    schema "SNOWFLEX_TEST_MIXED_SCHEMA" do
+      field :label, :string
+      field :meta, :map
     end
   end
 
@@ -52,8 +64,26 @@ defmodule Snowflex.VariantIntegrationTest do
     :ok
   end
 
+  setup_all do
+    Http.query!("""
+    CREATE TABLE IF NOT EXISTS SNOWFLEX_TEST_MIXED_SCHEMA (
+      id VARCHAR NOT NULL,
+      label VARCHAR,
+      meta VARIANT
+    );
+    """)
+
+    :ok
+  end
+
   setup do
-    %{id: "row-#{:erlang.unique_integer([:positive])}}"}
+    id = "row-#{:erlang.unique_integer([:positive])}"
+
+    Http.query!("DELETE FROM SNOWFLEX_TEST_MAP_SCHEMA WHERE id = '#{id}';")
+    Http.query!("DELETE FROM SNOWFLEX_TEST_ARRAY_SCHEMA WHERE id = '#{id}';")
+    Http.query!("DELETE FROM SNOWFLEX_TEST_MIXED_SCHEMA WHERE id = '#{id}';")
+
+    %{id: id}
   end
 
   describe "map values" do
@@ -62,7 +92,7 @@ defmodule Snowflex.VariantIntegrationTest do
 
       Http.insert!(%SnowflexTestMapSchema{id: id, tags: tags})
 
-      assert %Snowflex.Result{rows: [written_tags]} =
+      assert %Snowflex.Result{rows: [[written_tags]]} =
                Http.query!("SELECT tags FROM SNOWFLEX_TEST_MAP_SCHEMA WHERE id = '#{id}';")
 
       assert Jason.decode!(written_tags) == tags
@@ -113,6 +143,111 @@ defmodule Snowflex.VariantIntegrationTest do
 
       assert %SnowflexTestArraySchema{names: ^names, ages: ^ages, things: ^things} =
                Http.get(SnowflexTestArraySchema, id)
+    end
+  end
+
+  describe "update variant fields (corruption-fix proof)" do
+    test "update :map field to new map round-trips as parsed JSON, not a quoted string", %{
+      id: id
+    } do
+      original = %{"version" => 1}
+      updated = %{"version" => 2, "extra" => "data"}
+
+      row = %SnowflexTestMapSchema{id: id, tags: original}
+      Http.insert!(row)
+
+      changeset = Changeset.change(row, tags: updated)
+      Http.update!(changeset)
+
+      assert %SnowflexTestMapSchema{tags: ^updated} = Http.get(SnowflexTestMapSchema, id)
+    end
+
+    test "update {:array, _} field to new list round-trips correctly", %{id: id} do
+      original_names = ["Alice"]
+      updated_names = ["Alice", "Bob", "Carol"]
+
+      row = %SnowflexTestArraySchema{id: id, names: original_names, ages: [], things: []}
+      Http.insert!(row)
+
+      changeset = Changeset.change(row, names: updated_names)
+      Http.update!(changeset)
+
+      assert %SnowflexTestArraySchema{names: ^updated_names} =
+               Http.get(SnowflexTestArraySchema, id)
+    end
+
+    test "update a variant col and a plain field together in one changeset", %{id: id} do
+      original_meta = %{"v" => 1}
+      updated_meta = %{"v" => 2}
+      original_label = "before"
+      updated_label = "after"
+
+      row = %SnowflexTestMixedSchema{id: id, label: original_label, meta: original_meta}
+      Http.insert!(row)
+
+      changeset = Changeset.change(row, label: updated_label, meta: updated_meta)
+      Http.update!(changeset)
+
+      assert %SnowflexTestMixedSchema{label: ^updated_label, meta: ^updated_meta} =
+               Http.get(SnowflexTestMixedSchema, id)
+    end
+
+    test "update a variant field to nil stores SQL NULL and reads back nil", %{id: id} do
+      row = %SnowflexTestMapSchema{id: id, tags: %{"key" => "value"}}
+      Http.insert!(row)
+
+      changeset = Changeset.change(row, tags: nil)
+      Http.update!(changeset)
+
+      assert %SnowflexTestMapSchema{tags: nil} = Http.get(SnowflexTestMapSchema, id)
+    end
+
+    test "delete by id returns nil from Http.get", %{id: id} do
+      row = %SnowflexTestMapSchema{id: id, tags: %{"x" => 1}}
+      Http.insert!(row)
+
+      Http.delete!(row)
+
+      assert nil == Http.get(SnowflexTestMapSchema, id)
+    end
+  end
+
+  describe "update_all variant fields (PARSE_JSON wrap)" do
+    test "update_all on a :map column stores a parsed object, not a quoted JSON string", %{
+      id: id
+    } do
+      import Ecto.Query
+
+      original = %{"version" => 1}
+      new_tags = %{"version" => 2, "extra" => "data"}
+
+      Http.insert!(%SnowflexTestMapSchema{id: id, tags: original})
+
+      Http.update_all(
+        from(r in SnowflexTestMapSchema, where: r.id == ^id),
+        set: [tags: new_tags]
+      )
+
+      # After update_all the row must round-trip as a parsed map, not a quoted
+      # JSON string stored as a scalar VARIANT.
+      assert %SnowflexTestMapSchema{tags: ^new_tags} = Http.get(SnowflexTestMapSchema, id)
+    end
+
+    test "update_all on a {:array, _} column stores a parsed array, not a quoted JSON string",
+         %{id: id} do
+      import Ecto.Query
+
+      original_names = ["Alice"]
+      new_names = ["Alice", "Bob", "Carol"]
+
+      Http.insert!(%SnowflexTestArraySchema{id: id, names: original_names, ages: [], things: []})
+
+      Http.update_all(
+        from(r in SnowflexTestArraySchema, where: r.id == ^id),
+        set: [names: new_names]
+      )
+
+      assert %SnowflexTestArraySchema{names: ^new_names} = Http.get(SnowflexTestArraySchema, id)
     end
   end
 end

--- a/test/snowflex/ecto/adapter/connection_test.exs
+++ b/test/snowflex/ecto/adapter/connection_test.exs
@@ -22,8 +22,8 @@ defmodule Snowflex.Ecto.Adapter.ConnectionTest do
     IO.iodata_to_binary(SQL.insert(prefx, table, header, rows, on_conflict, returning, []))
   end
 
-  defp update(prefx, table, fields, filter, returning) do
-    IO.iodata_to_binary(SQL.update(prefx, table, fields, filter, returning))
+  defp update(prefx, table, fields, filter, returning, opts \\ []) do
+    IO.iodata_to_binary(SQL.update(prefx, table, fields, filter, returning, opts))
   end
 
   defp delete(prefx, table, filter, returning) do
@@ -888,6 +888,26 @@ defmodule Snowflex.Ecto.Adapter.ConnectionTest do
     assert update_all(query) == ~s{UPDATE first.schema AS s0 SET s0.x = 0}
   end
 
+  test "update_all wraps VARIANT set-fields in PARSE_JSON and leaves plain fields as bare ?" do
+    # TestSchema has field :meta of type :map (VARIANT) and :x of type :integer (plain).
+    # A pinned param {:^, [], [ix]} produces "?" from expr/3. When the field is a VARIANT
+    # type, update_all must emit "PARSE_JSON(?)" instead of bare "?".
+    query =
+      from(m in TestSchema, update: [set: [meta: ^%{"k" => 1}, x: ^42]])
+      |> plan(:update_all)
+
+    sql = update_all(query)
+
+    assert sql =~ "s0.meta = PARSE_JSON(?)",
+           "expected VARIANT field meta to be wrapped in PARSE_JSON(?), got: #{sql}"
+
+    assert sql =~ "s0.x = ?",
+           "expected plain integer field x to be bare ?, got: #{sql}"
+
+    refute sql =~ "s0.x = PARSE_JSON",
+           "plain integer field x must NOT be wrapped in PARSE_JSON, got: #{sql}"
+  end
+
   test "delete all" do
     query = TestSchema |> Queryable.to_query() |> plan()
     assert delete_all(query) == ~s{DELETE  FROM schema AS s0}
@@ -1329,6 +1349,87 @@ defmodule Snowflex.Ecto.Adapter.ConnectionTest do
                  end
   end
 
+  # Characterization test: variant/map/array fields are detected and wrapped in PARSE_JSON(?).
+  # This test MUST stay GREEN through any refactor of json_fields_from_schema_meta/1.
+  describe "variant field detection and PARSE_JSON wrapping" do
+    defp insert_with_json_fields(header, rows, json_fields) do
+      SQL.insert(nil, "variant_schema", header, rows, {:raise, [], []}, [], [],
+        json_fields: json_fields
+      )
+      |> IO.iodata_to_binary()
+    end
+
+    test "non-variant fields use plain ? placeholder" do
+      sql = insert_with_json_fields([:plain_name], [[:plain_name]], [])
+      assert sql == ~s{INSERT INTO variant_schema (plain_name) VALUES (?)}
+    end
+
+    test ":map field is wrapped in PARSE_JSON(?) when listed in json_fields" do
+      sql =
+        insert_with_json_fields(
+          [:plain_name, :map_field],
+          [[:plain_name, :map_field]],
+          [:map_field]
+        )
+
+      assert sql ==
+               ~s{INSERT INTO variant_schema (plain_name,map_field) } <>
+                 ~s{SELECT ?,PARSE_JSON(?)}
+    end
+
+    test "{:map, _} field is wrapped in PARSE_JSON(?) when listed in json_fields" do
+      sql =
+        insert_with_json_fields(
+          [:plain_name, :typed_map_field],
+          [[:plain_name, :typed_map_field]],
+          [:typed_map_field]
+        )
+
+      assert sql ==
+               ~s{INSERT INTO variant_schema (plain_name,typed_map_field) } <>
+                 ~s{SELECT ?,PARSE_JSON(?)}
+    end
+
+    test "{:array, _} field is wrapped in PARSE_JSON(?) when listed in json_fields" do
+      sql =
+        insert_with_json_fields(
+          [:plain_name, :array_field],
+          [[:plain_name, :array_field]],
+          [:array_field]
+        )
+
+      assert sql ==
+               ~s{INSERT INTO variant_schema (plain_name,array_field) } <>
+                 ~s{SELECT ?,PARSE_JSON(?)}
+    end
+
+    test "multiple variant fields in a single insert all get PARSE_JSON(?)" do
+      sql =
+        insert_with_json_fields(
+          [:plain_int, :map_field, :array_field],
+          [[:plain_int, :map_field, :array_field]],
+          [:map_field, :array_field]
+        )
+
+      assert sql ==
+               ~s{INSERT INTO variant_schema (plain_int,map_field,array_field) } <>
+                 ~s{SELECT ?,PARSE_JSON(?),PARSE_JSON(?)}
+    end
+
+    test "variant fields among non-variant fields only wrap the variant ones" do
+      sql =
+        insert_with_json_fields(
+          [:plain_name, :map_field, :plain_int],
+          [[:plain_name, :map_field, :plain_int]],
+          [:map_field]
+        )
+
+      assert sql ==
+               ~s{INSERT INTO variant_schema (plain_name,map_field,plain_int) } <>
+                 ~s{SELECT ?,PARSE_JSON(?),?}
+    end
+  end
+
   test "insert with query" do
     select_query = from("schema", select: [:id]) |> plan(:all)
 
@@ -1363,6 +1464,21 @@ defmodule Snowflex.Ecto.Adapter.ConnectionTest do
 
     query = update("prefix", "schema", [:id], [x: 1, y: nil], [])
     assert query == ~s{UPDATE prefix.schema SET id = ? WHERE x = ? AND y IS NULL}
+  end
+
+  test "update wraps variant set-fields in PARSE_JSON(?)" do
+    query = update(nil, "schema", [:meta, :name], [id: 1], [], json_fields: [:meta])
+    assert query == ~s{UPDATE schema SET meta = PARSE_JSON(?), name = ? WHERE id = ?}
+  end
+
+  test "update without json_fields leaves all set-fields as plain ?" do
+    query = update(nil, "schema", [:id], [x: 1, y: 2], [])
+    assert query == ~s{UPDATE schema SET id = ? WHERE x = ? AND y = ?}
+  end
+
+  test "update with nil filter and variant set-field uses PARSE_JSON(?) and IS NULL" do
+    query = update("prefix", "schema", [:meta], [x: nil], [], json_fields: [:meta])
+    assert query == ~s{UPDATE prefix.schema SET meta = PARSE_JSON(?) WHERE x IS NULL}
   end
 
   test "delete" do


### PR DESCRIPTION
Snowflake's data-type-conversion matrix lists VARCHAR as castable but NOT coercible to VARIANT, so loading JSON text into a VARIANT column requires an explicit PARSE_JSON()/cast. INSERT already did this (PR #172), but UPDATE and update_all emitted `col = ?` — binding the JSON-encoded string as TEXT and relying on implicit VARCHAR->VARIANT coercion that is undocumented and contradicts Snowflake's conversion rules (INSERT rejects it outright with "expecting VARIANT but got VARCHAR"). This makes variant writes use the documented PARSE_JSON path consistently across insert, update, and update_all.

- Add Snowflex.VariantField.variant_field?/1 as the single source of truth for variant-field detection (:map, {:map,_}, {:array,_}); used by the adapter's json_fields detection and by update_all SQL generation.
- update/6 (Repo.update) and update_all wrap variant set-fields in PARSE_JSON(?); schemaless update_all is unchanged; bind/param order unchanged.
- Add SQL-generation unit guards for INSERT, UPDATE, and update_all wrapping.
- Add integration coverage for variant update / update_all round-trips and delete; fix test isolation (per-test cleanup) and map-write row shape.