### PR TITLE
Enable gzip decompression for Snowflake API responses

### DIFF
--- a/lib/snowflex/transport/http.ex
+++ b/lib/snowflex/transport/http.ex
@@ -634,7 +634,8 @@ defmodule Snowflex.Transport.Http do
       retry_delay: fn attempt ->
         calculate_backoff_delay(attempt, state.retry_base_delay, state.retry_max_delay)
       end,
-      max_retries: state.max_retries
+      max_retries: state.max_retries,
+      compressed: true
     ]
 
     base_options

--- a/test/transport/http_test.exs
+++ b/test/transport/http_test.exs
@@ -293,5 +293,10 @@ defmodule Snowflex.Transport.HttpTest do
       assert Keyword.get(built, :connect_options) == []
       refute Keyword.has_key?(built, :finch)
     end
+
+    test "enables compressed (gzip) by default" do
+      assert {:ok, built} = Http.options(@private_key_opts)
+      assert Keyword.get(built, :compressed) == true
+    end
   end
 end


### PR DESCRIPTION
## Problem

Snowflake's REST API returns gzip-compressed responses with `Content-Encoding: gzip` on partition fetches for large result sets. Req's `decompress_body` step is gated behind the `compressed` option (defaults to `false`), so these responses pass through as raw binary. Downstream code then crashes with a `BadMapError` when it calls `Map.get/3` on the gzip bytes instead of a decoded JSON map:

```elixir
** (BadMapError) expected a map, got:
    <<31, 139, 8, 0, ...>>
    (elixir) lib/map.ex:541: Map.get(<<31, 139, ...>>, "data", [])
    (snowflex) lib/snowflex/transport/http.ex:454:
      Snowflex.Transport.Http.gather_results/3
```

## Cause

Req v0.6.0 (June 2026) flipped the `compressed` option from defaulting to `true` to `false` as part of a security fix for decompression bombs ([GHSA-655f-mp8p-96gv][advisory], [commit 84977e5][commit]).

Previously, Req's `decompress_body` step ran automatically on every response. Now it only runs when `compressed: true` is explicitly set. Since `build_options/1` never set this option, gzipped responses from Snowflake pass through as raw binary.

Without `compressed: true`, Req skips decompression entirely -- even when the server sends `Content-Encoding: gzip`. The Req docs and source confirm this:

1. [`compressed/1`](https://hexdocs.pm/req/Req.Steps.html#compressed/1)
   request step: *"Asks the server to return compressed response. This
   step also enables the `decompress_body` step, which decompresses the
   response body. Both steps are off by default; set `compressed: true`
   to opt in."*
2. [`decompress_body/1`](https://hexdocs.pm/req/Req.Steps.html#decompress_body/1)
   response step: *"This step only runs when the `:compressed` option is
   set to `true`; otherwise the body is left as is."*
3. The [source code](https://github.com/wojtekmach/req/blob/36a82523e864739787340604f65ecce26699a0a9/lib/req/steps.ex#L1595-L1627)
   confirms it:

```elixir
compressed? = Req.Request.get_option(request, :compressed, false) == true
if not compressed? or raw? do
  {request, response}  # skips decompression
```

Confirmed via `:dbg` tracing against a live Snowflake instance -- partition responses arrive with `Content-Encoding: gzip` and gzip magic bytes (`<<31, 139>>`), but Req skips decompression entirely.

## Fix

Add `compressed: true` to the base options in `build_options/1`. This tells Req to:

1. Send `Accept-Encoding: gzip` on outgoing requests
2. Automatically decompress gzip responses via its `decompress_body` step

Req defaults `compressed` to `false` to guard against decompression bombs from untrusted servers. This is safe here because Snowflex only connects to authenticated Snowflake API endpoints.

## Testing

- Unit test added asserting `compressed: true` is present in built options
- Tested against a live Snowflake instance via `SNOWFLEX_PATH` -- previously-crashing queries now succeed

## Changes

- `lib/snowflex/transport/http.ex` -- Add `compressed: true` to `build_options/1` base options
- `test/transport/http_test.exs` -- Add test asserting `compressed: true` is present in built options

[advisory]: https://github.com/wojtekmach/req/security/advisories/GHSA-655f-mp8p-96gv
[commit]: https://github.com/wojtekmach/req/commit/84977e5b1a83f26e749d55ad06e3625464af4e8d
