### PR TITLE
Bump version to 1.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.4.1] - 2026-06-17
+
+### Bug Fixes
+
+- Enable gzip decompression for Snowflake API responses. Req v0.6.0 flipped the `compressed` option from `true` to `false` by default ([GHSA-655f-mp8p-96gv](https://github.com/wojtekmach/req/security/advisories/GHSA-655f-mp8p-96gv)), causing partition fetches to return raw gzip bytes instead of decoded JSON. `build_options/1` now explicitly sets `compressed: true`. ([#181](https://github.com/pepsico-ecommerce/snowflex/pull/181))
+
 ## [1.4.0] - 2026-06-16
 
 ### Enhancements

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Snowflex.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/pepsico-ecommerce/snowflex"
-  @version "1.4.0"
+  @version "1.4.1"
 
   def project do
     [


### PR DESCRIPTION
Release 1.4.1 — enables gzip decompression for Snowflake API responses, restoring behavior lost when Req v0.6.0/v0.6.1 defaulted compressed to false (#181).